### PR TITLE
Drop ungrounded (empty-gene) disrupted pathways from the impact table

### DIFF
--- a/R/narrative.R
+++ b/R/narrative.R
@@ -578,16 +578,19 @@ py_disrupted_pathways_to_tibble <- function(x) {
         description = purrr::map_chr(x, ~ .x$description %||% NA_character_),
         dysregulated_genes = purrr::map_chr(x, ~ {
           dg <- .x$dysregulated_genes
-          # Empty list / NULL — happens when the LLM correctly returns no genes
-          # for a pathway (per the Phase-2 prompt). Treat as NA, not as an
-          # error, so other pathways for this cell still survive.
           if (is.null(dg) || length(dg) == 0) return(NA_character_)
           if (is.list(dg)) dg <- unlist(dg)
           dg <- as.character(dg)
           dg <- dg[!is.na(dg) & nzchar(dg)]
           if (length(dg) == 0) NA_character_ else paste(dg, collapse = ", ")
         })
-      )
+      ) %>%
+        # Drop pathways the model named but could not ground in any gene from
+        # <allowed_genes>. An ungrounded pathway carries no cell-specific
+        # evidence; empirically these are the model anchoring on the
+        # perturbation's canonical function (e.g. naming a myogenic pathway in a
+        # non-muscle cell) rather than reading this cell's data. Demote-only.
+        dplyr::filter(!is.na(.data$dysregulated_genes))
     },
     error = function(e) {
       preview <- paste(utils::capture.output(str(x, max.level = 2)), collapse = " ")


### PR DESCRIPTION
# What
`py_disrupted_pathways_to_tibble` kept pathways the LLM named but could not ground in any gene
from `<allowed_genes>` (empty `dysregulated_genes` → `NA`), on the assumption the model
"correctly returns no genes." Filter them out: a disrupted pathway with no supporting gene
carries no cell-specific evidence.

## Why
In practice these empty pathways are the model **anchoring** on the perturbation's canonical
function — e.g. naming a myogenic pathway in a non-muscle cell with nothing from that cell's
data to back it. This is a demote-only backstop to the grounded-prompt change in
zscapeaitools (which stops them being generated in the first place); together they took
empty-gene pathways from ~7% to 0 on the myod1/six1a/six1b panel.

## Companion PRs (coordinated change)
- `cole-trapnell-lab/zscapeaitools` — the reasoning fix + grounded prompt (v2).
- `cole-trapnell-lab/mcclintock` — expose `no_think`/`max_tokens` params, default to grounded no-think.