### PR TITLE
empirical-FDR: a count-calibrated t for count support (replaces SE floor + n_eff df-correction)

### DIFF
--- a/R/empirical_fdr_model.R
+++ b/R/empirical_fdr_model.R
@@ -27,6 +27,13 @@ NULL
 .EFDR_EGRID  <- seq(-9, 1, 0.25)      # expression grid the tail surface is evaluated on
 .EFDR_PEGRID <- seq(0, 100, 10)       # %embryos grid (control detection rate)
 
+# --- The empirical-null policy (one set of baked constants; not pipeline-configurable) ---
+.EFDR_C_FULL <- 10    # cells an embryo must carry to count as ONE full perturbation replicate;
+                      # below this it contributes fractionally (cells / c_full). Drives the
+                      # cell-count-aware degrees-of-freedom of the within-state contrast.
+.EFDR_MIN_PB <- 2L    # a cell type needs at least this many perturbation embryos to have a
+                      # valid two-group contrast; below it, calls are gated (empirical_p = 1).
+
 #' Build a control-split empirical null for the DEG artifact.
 #'
 #' Relabels control samples as a pseudo-perturbation at several split sizes, runs
@@ -57,7 +64,6 @@ build_empirical_null <- function(cds,
                                  nperm = 10000L,
                                  cores = 1L,
                                  seed = 42L,
-                                 min_cells_for_support = 1L,
                                  max_simultaneous_genes = 2000L,
                                  write_dir = tempfile("efdr_null_"),
                                  verbose = TRUE) {
@@ -119,11 +125,10 @@ build_empirical_null <- function(cds,
     # trend-dispersion shrinkage buys back df, so the effective df exceeds n_pert_pb - 1;
     # the null is the reference for how much).
     supp <- efdr_perturbation_support(sub, sample_group = sample_group, cell_group = cell_group,
-                                      control_ids = "ctrl-inj", perturbation_col = perturbation_col,
-                                      min_cells = min_cells_for_support)
+                                      control_ids = "ctrl-inj", perturbation_col = perturbation_col)
     .read_null_dir(wd) %>%
       dplyr::left_join(det, by = c("gene_short_name", "cell_group")) %>%
-      dplyr::left_join(supp[, c("cell_group", "n_pert_pb")], by = "cell_group") %>%
+      dplyr::left_join(supp[, c("cell_group", "n_pert_pb", "n_eff_pb")], by = "cell_group") %>%
       dplyr::mutate(log_ratio = log2(N / (n_ctrl - N)))
   })
 }
@@ -223,18 +228,23 @@ efdr_perturbation_support <- function(cds,
                                       sample_group = "embryo_ID",
                                       cell_group = "cell_type",
                                       control_ids = c("ctrl-inj"),
-                                      perturbation_col = "perturbation",
-                                      min_cells = 1L) {
+                                      perturbation_col = "perturbation") {
   cd <- SummarizedExperiment::colData(cds)
   df <- tibble::tibble(ct = as.character(cd[[cell_group]]),
                        emb = as.character(cd[[sample_group]]),
                        is_ctrl = as.character(cd[[perturbation_col]]) %in% control_ids)
   df %>%
     dplyr::count(.data$ct, .data$emb, .data$is_ctrl, name = "n") %>%
-    dplyr::filter(.data$n >= min_cells) %>%
     dplyr::group_by(.data$ct) %>%
     dplyr::summarise(n_pert_pb = dplyr::n_distinct(.data$emb[!.data$is_ctrl]),
                      n_ctrl_pb = dplyr::n_distinct(.data$emb[.data$is_ctrl]),
+                     # Cell-weighted effective perturbation replicates: an embryo counts as a
+                     # FULL replicate only once it carries `.EFDR_C_FULL` cells of this type;
+                     # below that it contributes fractionally, because a near-empty pseudobulk
+                     # carries almost no information and its shrunken SE is over-confident.
+                     # This is the df-driving support; the raw embryo count `n_pert_pb` still
+                     # drives the gate.
+                     n_eff_pb = sum(pmin(1, .data$n[!.data$is_ctrl] / .EFDR_C_FULL)),
                      .groups = "drop") %>%
     dplyr::rename(cell_group = "ct")
 }
@@ -275,8 +285,6 @@ train_efdr_model <- function(null, detection = NULL, taus = .EFDR_TAUS,
                                by = c("gene_short_name", "cell_group"))
     }
   }
-  if (!"pct_emb" %in% names(null)) null$pct_emb <- NA_real_
-  if (!"pct_emb_pert" %in% names(null)) null$pct_emb_pert <- null$pct_emb  # degrade: reuse control detection
   null <- null %>%
     dplyr::filter(is.finite(.data$log_mean_expression), is.finite(.data$z)) %>%
     dplyr::mutate(dir = dplyr::if_else(.data$z < 0, "dn", "up"), a = abs(.data$z))
@@ -322,25 +330,28 @@ train_efdr_model <- function(null, detection = NULL, taus = .EFDR_TAUS,
     surf[[key]] <- Q
   }
   df_calib <- .efdr_calibrate_df(null)
+  if (is.null(df_calib))
+    stop("efdr: could not calibrate degrees-of-freedom from the null (too few draws). ",
+         "A valid efdr_model requires the support->df calibration.", call. = FALSE)
   structure(list(surf = surf, taus = taus, egrid = egrid, pegrid = pegrid, ratios = ratios,
                  df_calib = df_calib),
             class = "efdr_model")
 }
 
 # Calibrate the honest effective degrees-of-freedom of the within-state contrast as a
-# function of perturbation-arm replicate support (n_pert_pb). Naive Welch says the df is
-# n_pert_pb - 1, but the trend-dispersion shrinkage borrows dispersion across genes and
-# buys real df back, so the effective df is higher. The null is the reference: at moderate
-# expression (isolating the sample-size effect from the low-expression artifact the surface
-# already prices), match the null |z| right-tail exceedance at `z0` to a t-distribution and
-# solve for its df. Returns a monotone (support -> df) lookup; NA/absent -> no support in
-# the null -> annotate falls back to Welch. NULL if the null lacks n_pert_pb (back-compat).
+# function of the cell-weighted effective perturbation support (n_eff_pb). Naive Welch says
+# the df is (replicates - 1), but the trend-dispersion shrinkage borrows dispersion across
+# genes and buys real df back, so the effective df is higher. The null is the reference: at
+# moderate expression (isolating the sample-size effect from the low-expression artifact the
+# surface already prices), match the null |z| right-tail exceedance at `z0` to a
+# t-distribution and solve for its df. Returns a monotone (support -> df) lookup; NULL only
+# if the null has too few draws to calibrate (train_efdr_model then errors).
 .efdr_calibrate_df <- function(null, z0 = 3.5, min_n = 500L) {
-  if (!"n_pert_pb" %in% names(null)) return(NULL)
-  d <- null[is.finite(null$n_pert_pb) & is.finite(null$z) &
+  d <- null[is.finite(null$n_eff_pb) & is.finite(null$z) &
               is.finite(null$log_mean_expression) & null$log_mean_expression > -1, ]
   if (nrow(d) < min_n) return(NULL)
-  a <- abs(d$z); k <- d$n_pert_pb
+  a <- abs(d$z); k <- d$n_eff_pb
+  kb <- round(k)                                        # bin continuous effective support to integer levels
   solve_df <- function(p) {                              # 2*pt(-z0, df) is decreasing in df
     if (!is.finite(p) || p <= 2 * stats::pnorm(-z0)) return(Inf)  # normal already conservative
     g <- function(l) 2 * stats::pt(-z0, exp(l)) - p
@@ -348,10 +359,10 @@ train_efdr_model <- function(null, detection = NULL, taus = .EFDR_TAUS,
     if (g(log(1e4)) > 0) return(Inf)
     exp(stats::uniroot(g, c(log(0.5), log(1e4)))$root)
   }
-  levs <- sort(unique(k[k >= 2]))
+  levs <- sort(unique(kb[kb >= 2]))
   rows <- lapply(levs, function(kk) {
-    ak <- a[k == kk]; if (length(ak) < min_n) return(NULL)
-    data.frame(n_pert_pb = kk, df_eff = solve_df(mean(ak >= z0)), n = length(ak))
+    ak <- a[kb == kk]; if (length(ak) < min_n) return(NULL)
+    data.frame(support = kk, df_eff = solve_df(mean(ak >= z0)), n = length(ak))
   })
   out <- do.call(rbind, rows)
   if (is.null(out) || nrow(out) < 2L) return(NULL)
@@ -360,8 +371,8 @@ train_efdr_model <- function(null, detection = NULL, taus = .EFDR_TAUS,
   # the t-distribution is indistinguishable from normal so the correction is negligible.
   df_cap <- 60
   y <- pmin(out$df_eff, df_cap)
-  out$df_eff <- stats::isoreg(out$n_pert_pb, y)$yf
-  out[, c("n_pert_pb", "df_eff")]
+  out$df_eff <- stats::isoreg(out$support, y)$yf
+  out[, c("support", "df_eff")]
 }
 
 # right-tail probability of |z| = `a` at (expression `e`, %embryos `pe`) against a
@@ -405,7 +416,7 @@ train_efdr_model <- function(null, detection = NULL, taus = .EFDR_TAUS,
 #'     promote one.
 #' @export
 annotate_empirical_fdr_model <- function(model, deg_tbl, log_ratio, detection = NULL,
-                                         support = NULL, min_pseudobulks = 2L,
+                                         support = NULL, min_pseudobulks = .EFDR_MIN_PB,
                                          group_col = "cell_group") {
   R <- model$ratios
   br <- if (log_ratio <= R[1]) list(lo = R[1], hi = R[1], w = 1) else
@@ -422,24 +433,28 @@ annotate_empirical_fdr_model <- function(model, deg_tbl, log_ratio, detection = 
     deg_tbl <- dplyr::left_join(deg_tbl, detection, by = c("gene_short_name", "cell_group"))
   }
   if (!is.null(support)) {
-    deg_tbl <- deg_tbl[, setdiff(names(deg_tbl), "n_pert_pb"), drop = FALSE]
-    deg_tbl <- dplyr::left_join(deg_tbl, support[, c("cell_group", "n_pert_pb")], by = "cell_group")
+    supp_cols <- intersect(c("n_pert_pb", "n_eff_pb"), names(support))
+    deg_tbl <- deg_tbl[, setdiff(names(deg_tbl), supp_cols), drop = FALSE]
+    deg_tbl <- dplyr::left_join(deg_tbl, support[, c("cell_group", supp_cols)], by = "cell_group")
   }
-  if (!"pct_emb" %in% names(deg_tbl)) deg_tbl$pct_emb <- NA_real_
-  if (!"pct_emb_pert" %in% names(deg_tbl)) deg_tbl$pct_emb_pert <- deg_tbl$pct_emb  # degrade gracefully
-  if (!"n_pert_pb" %in% names(deg_tbl)) deg_tbl$n_pert_pb <- NA_real_
-
-  # Map perturbation-arm support -> honest effective df. Prefer the null-calibrated
-  # (support -> df) lookup carried by the model (accounts for the shrinkage's df buy-back,
-  # so it is much milder than Welch); fall back to the Welch limit (n_pert_pb - 1) only if
-  # the model carries no calibration (older null). df_eff = Inf -> no df-correction.
+  # Map effective perturbation-arm support (n_eff_pb) -> honest effective df. Within the
+  # range the null covers, use the null-calibrated (support -> df) lookup (accounts for the
+  # shrinkage's df buy-back). BELOW the smallest calibrated support the control-split null
+  # has no coverage (its cell types are well-populated), so df is ramped analytically from a
+  # 0.5 floor at <=1 effective replicate up to the smallest calibrated df -- this is what
+  # demotes cell types that are thin *in cells* (n_eff -> 0), whose over-shrunk SE would
+  # otherwise manufacture a confident call.
   cal <- model$df_calib
-  dfmap <- if (!is.null(cal) && nrow(cal) >= 1) function(n) {
-      out <- rep(NA_real_, length(n)); ok <- is.finite(n)
-      idx <- findInterval(n[ok], cal$n_pert_pb)           # clamp below -> smallest calibrated level
-      out[ok] <- cal$df_eff[pmin(pmax(idx, 1L), nrow(cal))]
-      out
-    } else function(n) n - 1
+  s0 <- cal$support[1]; d0 <- cal$df_eff[1]              # smallest calibrated support and its df
+  dfmap <- function(n) {
+    out <- rep(NA_real_, length(n)); ok <- is.finite(n); nn <- n[ok]
+    idx <- findInterval(nn, cal$support)                 # within/above range: step lookup
+    val <- cal$df_eff[pmin(pmax(idx, 1L), nrow(cal))]
+    below <- nn < s0                                     # extend below the calibrated floor
+    val[below] <- if (s0 > 1) pmax(0.5, 0.5 + (d0 - 0.5) * (nn[below] - 1) / (s0 - 1)) else 0.5
+    out[ok] <- val
+    out
+  }
 
   out <- deg_tbl %>%
     dplyr::mutate(
@@ -455,7 +470,7 @@ annotate_empirical_fdr_model <- function(model, deg_tbl, log_ratio, detection = 
       # (depleted cell types where the deep control arm lends unearned power) at the same
       # decorate-in-place layer, with no DEG re-fit; it is a pure function of KO support, so
       # it does not touch expression and cannot demote well-supported calls.
-      .df = dfmap(.data$n_pert_pb),
+      .df = dfmap(.data$n_eff_pb),
       .p_df = dplyr::if_else(is.finite(.data$.df),
                              2 * stats::pt(-.data$.a, df = pmax(.data$.df, 0.5)), NA_real_),
       .ord_p = if ("perturb_to_ctrl_p_value" %in% names(.)) .data$perturb_to_ctrl_p_value

--- a/R/empirical_fdr_model.R
+++ b/R/empirical_fdr_model.R
@@ -126,22 +126,69 @@ build_empirical_null <- function(cds,
     # the null is the reference for how much).
     supp <- efdr_perturbation_support(sub, sample_group = sample_group, cell_group = cell_group,
                                       control_ids = "ctrl-inj", perturbation_col = perturbation_col)
-    .read_null_dir(wd) %>%
+    # Per-cell-type pseudo-arm CELL counts for THIS split, so the null z is SE-floored on the
+    # same footing as the real DEG (ctrl-inj = losing arm, NULLPERT = gaining arm).
+    cds_sub <- SummarizedExperiment::colData(sub)
+    ct_cells <- tibble::tibble(cell_group = as.character(cds_sub[[cell_group]]),
+                               is_ctrl = as.character(cds_sub[[perturbation_col]]) %in% "ctrl-inj") %>%
+      dplyr::group_by(.data$cell_group) %>%
+      dplyr::summarise(n_ctrl_cells = sum(.data$is_ctrl), n_pert_cells = sum(!.data$is_ctrl),
+                       .groups = "drop")
+    .read_null_dir(wd, ct_cells = ct_cells) %>%
       dplyr::left_join(det, by = c("gene_short_name", "cell_group")) %>%
       dplyr::left_join(supp[, c("cell_group", "n_pert_pb", "n_eff_pb")], by = "cell_group") %>%
       dplyr::mutate(log_ratio = log2(N / (n_ctrl - N)))
   })
 }
 
-.read_null_dir <- function(wd) {
+# Theoretical lower bound on the shrunken-LFC standard error. The trend-dispersion
+# shrinkage can manufacture an insane |z| on near-zero-count genes (a gene detected in <1%
+# of cells getting a tighter SE than a broadly-expressed one), and because the control-split
+# null is built from the same GLM its tail inherits the same insanity -- so the empirical
+# model can only demote so far. This caps the SE at the information the counts can actually
+# support: recover each arm's mean expression from the pooled mean, the fold change and the
+# arm cell counts, then apply the Poisson/delta-method floor se >= sqrt(1/K_ctrl + 1/K_pert)
+# on the effective counts K = N * mu. Well-powered calls are untouched (their real SE already
+# exceeds the floor); it is applied identically to the null and the real DEG so the statistic
+# and the distribution it is judged against stay on the same footing. LFC is natural-log.
+.efdr_se_floor <- function(log_mean_expression, lfc, n_ctrl, n_pert, kappa = 1) {
+  mu <- exp(log_mean_expression)
+  r  <- exp(lfc)                                        # mu_pert / mu_ctrl
+  denom <- n_ctrl + n_pert * r
+  mu_ctrl <- ifelse(denom > 0, mu * (n_ctrl + n_pert) / denom, mu)
+  K_ctrl <- pmax(n_ctrl * mu_ctrl, 0)
+  K_pert <- pmax(n_pert * mu_ctrl * r, 0)
+  sqrt(1 / (K_ctrl + kappa) + 1 / (K_pert + kappa))
+}
+
+# Apply the SE floor to a table carrying lfc/se/log_mean_expression + per-cell-type arm cell
+# counts (n_ctrl_cells, n_pert_cells), returning the floored standardized statistic.
+.efdr_floored_z <- function(lfc, se, log_mean_expression, n_ctrl_cells, n_pert_cells) {
+  ok <- is.finite(n_ctrl_cells) & is.finite(n_pert_cells)
+  se_fl <- se
+  se_fl[ok] <- pmax(se[ok], .efdr_se_floor(log_mean_expression[ok], lfc[ok],
+                                           n_ctrl_cells[ok], n_pert_cells[ok]))
+  lfc / se_fl
+}
+
+.read_null_dir <- function(wd, ct_cells = NULL) {
   files <- list.files(wd, "_within_node_degs.csv$", full.names = TRUE)
   if (!length(files)) return(tibble::tibble())
-  purrr::map_dfr(files, ~ suppressMessages(readr::read_csv(.x, show_col_types = FALSE))) %>%
+  d <- purrr::map_dfr(files, ~ suppressMessages(readr::read_csv(.x, show_col_types = FALSE))) %>%
     dplyr::filter(is.finite(.data$perturb_to_ctrl_shrunken_lfc),
                   .data$perturb_to_ctrl_shrunken_lfc_se > 0,
-                  is.finite(.data$log_mean_expression)) %>%
-    dplyr::transmute(.data$gene_short_name, .data$cell_group, .data$log_mean_expression,
-                     z = .data$perturb_to_ctrl_shrunken_lfc / .data$perturb_to_ctrl_shrunken_lfc_se) %>%
+                  is.finite(.data$log_mean_expression))
+  # Floor the SE with the split's per-cell-type pseudo-arm cell counts (same treatment the
+  # real DEG gets in annotate); fall back to the raw z if counts are unavailable.
+  if (!is.null(ct_cells)) {
+    d <- dplyr::left_join(d, ct_cells, by = "cell_group")
+    z <- .efdr_floored_z(d$perturb_to_ctrl_shrunken_lfc, d$perturb_to_ctrl_shrunken_lfc_se,
+                         d$log_mean_expression, d$n_ctrl_cells, d$n_pert_cells)
+  } else {
+    z <- d$perturb_to_ctrl_shrunken_lfc / d$perturb_to_ctrl_shrunken_lfc_se
+  }
+  tibble::tibble(gene_short_name = d$gene_short_name, cell_group = d$cell_group,
+                 log_mean_expression = d$log_mean_expression, z = z) %>%
     dplyr::filter(is.finite(.data$z))
 }
 
@@ -433,10 +480,12 @@ annotate_empirical_fdr_model <- function(model, deg_tbl, log_ratio, detection = 
     deg_tbl <- dplyr::left_join(deg_tbl, detection, by = c("gene_short_name", "cell_group"))
   }
   if (!is.null(support)) {
-    supp_cols <- intersect(c("n_pert_pb", "n_eff_pb"), names(support))
+    supp_cols <- intersect(c("n_pert_pb", "n_eff_pb", "n_ctrl_cells", "n_pert_cells"), names(support))
     deg_tbl <- deg_tbl[, setdiff(names(deg_tbl), supp_cols), drop = FALSE]
     deg_tbl <- dplyr::left_join(deg_tbl, support[, c("cell_group", supp_cols)], by = "cell_group")
   }
+  if (!"n_ctrl_cells" %in% names(deg_tbl)) deg_tbl$n_ctrl_cells <- NA_real_
+  if (!"n_pert_cells" %in% names(deg_tbl)) deg_tbl$n_pert_cells <- NA_real_
   # Map effective perturbation-arm support (n_eff_pb) -> honest effective df. Within the
   # range the null covers, use the null-calibrated (support -> df) lookup (accounts for the
   # shrinkage's df buy-back). BELOW the smallest calibrated support the control-split null
@@ -458,7 +507,15 @@ annotate_empirical_fdr_model <- function(model, deg_tbl, log_ratio, detection = 
 
   out <- deg_tbl %>%
     dplyr::mutate(
-      z = if ("z" %in% names(.)) .data$z
+      # SE-floored standardized statistic: cap the shrunken SE at the Poisson floor the counts
+      # support, so a near-zero gene can't get an insane |z| (same floor the null z got, so
+      # they stay on the same footing). Falls back to the raw z only if lfc/se/expression are
+      # absent (a caller that passed only `z`).
+      z = if (all(c("perturb_to_ctrl_shrunken_lfc", "perturb_to_ctrl_shrunken_lfc_se",
+                    "log_mean_expression") %in% names(.)))
+            .efdr_floored_z(.data$perturb_to_ctrl_shrunken_lfc, .data$perturb_to_ctrl_shrunken_lfc_se,
+                            .data$log_mean_expression, .data$n_ctrl_cells, .data$n_pert_cells)
+          else if ("z" %in% names(.)) .data$z
           else .data$perturb_to_ctrl_shrunken_lfc / .data$perturb_to_ctrl_shrunken_lfc_se,
       .dir = dplyr::if_else(.data$z < 0, "dn", "up"),
       .a = abs(.data$z),

--- a/R/empirical_fdr_model.R
+++ b/R/empirical_fdr_model.R
@@ -126,15 +126,9 @@ build_empirical_null <- function(cds,
     # the null is the reference for how much).
     supp <- efdr_perturbation_support(sub, sample_group = sample_group, cell_group = cell_group,
                                       control_ids = "ctrl-inj", perturbation_col = perturbation_col)
-    # Per-cell-type pseudo-arm CELL counts for THIS split, so the null z is SE-floored on the
-    # same footing as the real DEG (ctrl-inj = losing arm, NULLPERT = gaining arm).
-    cds_sub <- SummarizedExperiment::colData(sub)
-    ct_cells <- tibble::tibble(cell_group = as.character(cds_sub[[cell_group]]),
-                               is_ctrl = as.character(cds_sub[[perturbation_col]]) %in% "ctrl-inj") %>%
-      dplyr::group_by(.data$cell_group) %>%
-      dplyr::summarise(n_ctrl_cells = sum(.data$is_ctrl), n_pert_cells = sum(!.data$is_ctrl),
-                       .groups = "drop")
-    .read_null_dir(wd, ct_cells = ct_cells) %>%
+    # supp carries per-cell-type pseudo-arm cell counts (n_ctrl_cells, n_pert_cells), so the
+    # null z is SE-floored on the same footing as the real DEG.
+    .read_null_dir(wd, ct_cells = supp[, c("cell_group", "n_ctrl_cells", "n_pert_cells")]) %>%
       dplyr::left_join(det, by = c("gene_short_name", "cell_group")) %>%
       dplyr::left_join(supp[, c("cell_group", "n_pert_pb", "n_eff_pb")], by = "cell_group") %>%
       dplyr::mutate(log_ratio = log2(N / (n_ctrl - N)))
@@ -269,7 +263,7 @@ efdr_detection_rate <- function(cds,
 #'   a higher bar would wrongly drop cell types that are present across many embryos
 #'   but sparse per embryo (common in shallow captures). Matches the within-state DEG,
 #'   which fits on any embryo with cells (`min_cells_per_pseudobulk = NULL`).
-#' @return tibble(cell_group, n_pert_pb, n_ctrl_pb).
+#' @return tibble(cell_group, n_pert_pb, n_ctrl_pb, n_eff_pb, n_pert_cells, n_ctrl_cells).
 #' @export
 efdr_perturbation_support <- function(cds,
                                       sample_group = "embryo_ID",
@@ -277,22 +271,48 @@ efdr_perturbation_support <- function(cds,
                                       control_ids = c("ctrl-inj"),
                                       perturbation_col = "perturbation") {
   cd <- SummarizedExperiment::colData(cds)
-  df <- tibble::tibble(ct = as.character(cd[[cell_group]]),
-                       emb = as.character(cd[[sample_group]]),
-                       is_ctrl = as.character(cd[[perturbation_col]]) %in% control_ids)
+  efdr_support_from_coldata(
+    data.frame(emb  = as.character(cd[[sample_group]]),
+               pert = as.character(cd[[perturbation_col]]),
+               ct   = as.character(cd[[cell_group]]),
+               stringsAsFactors = FALSE),
+    sample_group = "emb", cell_group = "ct",
+    control_ids = control_ids, perturbation_col = "pert")
+}
+
+#' Per-cell-type perturbation-arm support, from a plain coldata table.
+#'
+#' The single source of truth for every support quantity the empirical-FDR model needs,
+#' computed from a (embryo, perturbation, cell_type) table so it can be driven from either a
+#' cell_data_set's colData ([efdr_perturbation_support()]) or a lightweight coldata TSV (the
+#' mcclintock efdr stage) without duplicating the definitions across repos:
+#'   - n_pert_pb   : perturbation embryos with the cell type (the gate's replicate count).
+#'   - n_ctrl_pb   : control embryos with the cell type.
+#'   - n_eff_pb    : cell-weighted effective perturbation replicates, sum min(1, cells/C_FULL)
+#'                   -- an embryo is a full replicate only once it carries `.EFDR_C_FULL`
+#'                   cells; drives the degrees-of-freedom correction.
+#'   - n_pert_cells / n_ctrl_cells : total cells per arm, feeding the theoretical SE floor.
+#' @param coldata data.frame/table with embryo, perturbation and cell-type columns.
+#' @param sample_group,cell_group,control_ids,perturbation_col column names / control labels.
+#' @export
+efdr_support_from_coldata <- function(coldata,
+                                      sample_group = "embryo_ID",
+                                      cell_group = "cell_type",
+                                      control_ids = c("ctrl-inj"),
+                                      perturbation_col = "perturbation") {
+  df <- tibble::tibble(ct = as.character(coldata[[cell_group]]),
+                       emb = as.character(coldata[[sample_group]]),
+                       is_ctrl = as.character(coldata[[perturbation_col]]) %in% control_ids)
   df %>%
     dplyr::count(.data$ct, .data$emb, .data$is_ctrl, name = "n") %>%
     dplyr::group_by(.data$ct) %>%
-    dplyr::summarise(n_pert_pb = dplyr::n_distinct(.data$emb[!.data$is_ctrl]),
-                     n_ctrl_pb = dplyr::n_distinct(.data$emb[.data$is_ctrl]),
-                     # Cell-weighted effective perturbation replicates: an embryo counts as a
-                     # FULL replicate only once it carries `.EFDR_C_FULL` cells of this type;
-                     # below that it contributes fractionally, because a near-empty pseudobulk
-                     # carries almost no information and its shrunken SE is over-confident.
-                     # This is the df-driving support; the raw embryo count `n_pert_pb` still
-                     # drives the gate.
-                     n_eff_pb = sum(pmin(1, .data$n[!.data$is_ctrl] / .EFDR_C_FULL)),
-                     .groups = "drop") %>%
+    dplyr::summarise(
+      n_pert_pb    = dplyr::n_distinct(.data$emb[!.data$is_ctrl]),
+      n_ctrl_pb    = dplyr::n_distinct(.data$emb[.data$is_ctrl]),
+      n_eff_pb     = sum(pmin(1, .data$n[!.data$is_ctrl] / .EFDR_C_FULL)),
+      n_pert_cells = sum(.data$n[!.data$is_ctrl]),
+      n_ctrl_cells = sum(.data$n[.data$is_ctrl]),
+      .groups = "drop") %>%
     dplyr::rename(cell_group = "ct")
 }
 

--- a/R/empirical_fdr_model.R
+++ b/R/empirical_fdr_model.R
@@ -33,6 +33,11 @@ NULL
                       # cell-count-aware degrees-of-freedom of the within-state contrast.
 .EFDR_MIN_PB <- 2L    # a cell type needs at least this many perturbation embryos to have a
                       # valid two-group contrast; below it, calls are gated (empirical_p = 1).
+.EFDR_MIN_ARM_UMI <- 1  # a (gene, cell type) needs >= this many total UMIs in AT LEAST ONE arm
+                      # to be callable; with both arms empty the gene is absent from the cell
+                      # type and its |z| is shrinkage noise (gated). Tests max(K_ctrl, K_pert),
+                      # so a well-counted control arm + empty perturbation arm (real complete
+                      # depletion) is KEPT -- only genuinely-absent genes are gated.
 
 #' Build a control-split empirical null for the DEG artifact.
 #'
@@ -120,69 +125,102 @@ build_empirical_null <- function(cds,
     # down-null on the losing (control) arm, as before.
     det <- efdr_detection_rate(sub, sample_group = sample_group, cell_group = cell_group,
                                control_ids = "ctrl-inj", perturbation_col = perturbation_col)
-    # Per-split perturbation-arm replicate support (NULLPERT pseudobulks per cell type):
-    # carried so the model can calibrate the honest degrees-of-freedom vs support (the
-    # trend-dispersion shrinkage buys back df, so the effective df exceeds n_pert_pb - 1;
-    # the null is the reference for how much).
+    # Per-cell-type embryo support: n_pert_pb still drives the <2-embryo gate.
     supp <- efdr_perturbation_support(sub, sample_group = sample_group, cell_group = cell_group,
                                       control_ids = "ctrl-inj", perturbation_col = perturbation_col)
-    # supp carries per-cell-type pseudo-arm cell counts (n_ctrl_cells, n_pert_cells), so the
-    # null z is SE-floored on the same footing as the real DEG.
-    .read_null_dir(wd, ct_cells = supp[, c("cell_group", "n_ctrl_cells", "n_pert_cells")]) %>%
+    # Per-(gene, cell_type) pseudo-arm UMI counts -> K_eff for the count-calibrated t, so df is
+    # calibrated against the same effective count the real DEG is scored on.
+    null_counts <- .efdr_arm_counts(sub, sample_group = sample_group, cell_group = cell_group,
+                                    control_ids = "ctrl-inj", perturbation_col = perturbation_col)
+    .read_null_dir(wd, counts = null_counts) %>%
       dplyr::left_join(det, by = c("gene_short_name", "cell_group")) %>%
-      dplyr::left_join(supp[, c("cell_group", "n_pert_pb", "n_eff_pb")], by = "cell_group") %>%
+      dplyr::left_join(supp[, c("cell_group", "n_pert_pb")], by = "cell_group") %>%
       dplyr::mutate(log_ratio = log2(N / (n_ctrl - N)))
   })
 }
 
-# Theoretical lower bound on the shrunken-LFC standard error. The trend-dispersion
-# shrinkage can manufacture an insane |z| on near-zero-count genes (a gene detected in <1%
-# of cells getting a tighter SE than a broadly-expressed one), and because the control-split
-# null is built from the same GLM its tail inherits the same insanity -- so the empirical
-# model can only demote so far. This caps the SE at the information the counts can actually
-# support: recover each arm's mean expression from the pooled mean, the fold change and the
-# arm cell counts, then apply the Poisson/delta-method floor se >= sqrt(1/K_ctrl + 1/K_pert)
-# on the effective counts K = N * mu. Well-powered calls are untouched (their real SE already
-# exceeds the floor); it is applied identically to the null and the real DEG so the statistic
-# and the distribution it is judged against stay on the same footing. LFC is natural-log.
-.efdr_se_floor <- function(log_mean_expression, lfc, n_ctrl, n_pert, kappa = 1) {
-  mu <- exp(log_mean_expression)
-  r  <- exp(lfc)                                        # mu_pert / mu_ctrl
-  denom <- n_ctrl + n_pert * r
-  mu_ctrl <- ifelse(denom > 0, mu * (n_ctrl + n_pert) / denom, mu)
-  K_ctrl <- pmax(n_ctrl * mu_ctrl, 0)
-  K_pert <- pmax(n_pert * mu_ctrl * r, 0)
-  sqrt(1 / (K_ctrl + kappa) + 1 / (K_pert + kappa))
+# Effective count backing a within-state contrast: the harmonic combination of the per-arm
+# total UMI counts, K_eff = 1/(1/K_ctrl + 1/K_pert), the reciprocal of the Poisson log-ratio
+# variance. The count-calibrated t is keyed on K_eff -- a near-empty arm (K_pert -> 0) gives
+# K_eff -> ~0, hence low calibrated df and a heavy tail that demotes the trend-dispersion
+# over-confidence on near-zero-count genes, while a well-counted call (large K_eff) gets a
+# near-normal tail and is untouched. It unifies the old cell-type df-correction and the SE
+# floor: both are "the counts don't support this confidence", at cell-type and per-gene
+# granularity respectively, and both are just low K_eff. It is a count-support GUARD BAND,
+# not a covariate-aware df -- "can the counts support a between-arm difference at all" holds
+# regardless of the model formula; the fine covariate df cost would need a nuisance-matched
+# null (see TODO). `kappa` guards the K = 0 singularity; the counts are real UMI totals.
+.efdr_keff <- function(K_ctrl, K_pert, kappa = 1) {
+  1 / (1 / (K_ctrl + kappa) + 1 / (K_pert + kappa))
 }
 
-# Apply the SE floor to a table carrying lfc/se/log_mean_expression + per-cell-type arm cell
-# counts (n_ctrl_cells, n_pert_cells), returning the floored standardized statistic.
-.efdr_floored_z <- function(lfc, se, log_mean_expression, n_ctrl_cells, n_pert_cells) {
-  ok <- is.finite(n_ctrl_cells) & is.finite(n_pert_cells)
-  se_fl <- se
-  se_fl[ok] <- pmax(se[ok], .efdr_se_floor(log_mean_expression[ok], lfc[ok],
-                                           n_ctrl_cells[ok], n_pert_cells[ok]))
-  lfc / se_fl
+# Per-(gene, cell_type, arm) total UMI counts from a cds, as a long table
+# (id, gene_short_name, cell_group, K_ctrl, K_pert). One grouped sum of the count matrix over
+# the cell_type x arm indicator -- the cheap one-off during a load we already do. Feeds the
+# count-calibrated t (K_eff = .efdr_keff(K_ctrl, K_pert)).
+#
+# KEYED ON `id` (= cds rownames = the DEG's unique feature id), NOT gene_short_name: multi-copy
+# families (histones etc.) share a gene_short_name across many Ensembl ids, so a gene_short_name
+# key is one-to-many and a downstream join on it silently duplicates DEG rows. `id` is unique.
+.efdr_arm_counts <- function(cds, sample_group = "embryo_ID", cell_group = "cell_type",
+                             control_ids = c("ctrl-inj"), perturbation_col = "perturbation") {
+  cd <- SummarizedExperiment::colData(cds)
+  ct <- as.character(cd[[cell_group]])
+  arm <- ifelse(as.character(cd[[perturbation_col]]) %in% control_ids, "ctrl", "pert")
+  grp <- factor(paste(ct, arm, sep = "\r"))
+  ind <- Matrix::sparseMatrix(i = seq_along(grp), j = as.integer(grp), x = 1,
+                              dims = c(length(grp), nlevels(grp)))
+  S <- as.matrix(monocle3::exprs(cds) %*% ind)          # genes x (cell_type|arm) raw UMI totals
+  ids <- rownames(cds)
+  gsym <- SummarizedExperiment::rowData(cds)$gene_short_name
+  if (is.null(gsym)) gsym <- ids
+  key <- strsplit(levels(grp), "\r", fixed = TRUE)
+  ct_lev <- vapply(key, `[`, "", 1); arm_lev <- vapply(key, `[`, "", 2)
+  # Build (id, cell_type) x {K_ctrl, K_pert} directly per cell type (no long/pivot).
+  res <- lapply(unique(ct_lev), function(ctype) {
+    jc <- which(ct_lev == ctype & arm_lev == "ctrl")
+    jp <- which(ct_lev == ctype & arm_lev == "pert")
+    data.frame(id = ids, gene_short_name = gsym, cell_group = ctype,
+               K_ctrl = if (length(jc)) S[, jc] else 0,
+               K_pert = if (length(jp)) S[, jp] else 0, stringsAsFactors = FALSE)
+  })
+  do.call(rbind, res)
 }
 
-.read_null_dir <- function(wd, ct_cells = NULL) {
+# Join per-(gene, cell) arm counts onto a table `x` on the unique feature id when both carry
+# it, else fall back to gene_short_name (deduplicating the counts by summing so the fallback
+# can never be one-to-many). Shared by the null build and the real-DEG annotation so K_eff is
+# computed the same way on both sides.
+.efdr_join_counts <- function(x, counts) {
+  if ("id" %in% names(x) && "id" %in% names(counts)) {
+    dplyr::left_join(x, counts[, c("id", "cell_group", "K_ctrl", "K_pert")],
+                     by = c("id", "cell_group"))
+  } else {
+    cnt <- counts %>%
+      dplyr::group_by(.data$gene_short_name, .data$cell_group) %>%
+      dplyr::summarise(K_ctrl = sum(.data$K_ctrl), K_pert = sum(.data$K_pert), .groups = "drop")
+    dplyr::left_join(x, cnt, by = c("gene_short_name", "cell_group"))
+  }
+}
+
+.read_null_dir <- function(wd, counts = NULL) {
   files <- list.files(wd, "_within_node_degs.csv$", full.names = TRUE)
   if (!length(files)) return(tibble::tibble())
   d <- purrr::map_dfr(files, ~ suppressMessages(readr::read_csv(.x, show_col_types = FALSE))) %>%
     dplyr::filter(is.finite(.data$perturb_to_ctrl_shrunken_lfc),
                   .data$perturb_to_ctrl_shrunken_lfc_se > 0,
                   is.finite(.data$log_mean_expression))
-  # Floor the SE with the split's per-cell-type pseudo-arm cell counts (same treatment the
-  # real DEG gets in annotate); fall back to the raw z if counts are unavailable.
-  if (!is.null(ct_cells)) {
-    d <- dplyr::left_join(d, ct_cells, by = "cell_group")
-    z <- .efdr_floored_z(d$perturb_to_ctrl_shrunken_lfc, d$perturb_to_ctrl_shrunken_lfc_se,
-                         d$log_mean_expression, d$n_ctrl_cells, d$n_pert_cells)
+  d$z <- d$perturb_to_ctrl_shrunken_lfc / d$perturb_to_ctrl_shrunken_lfc_se   # raw magnitude z
+  # Per-(gene, cell_type) effective count, so the count-calibrated t is calibrated against the
+  # same quantity the real DEG is scored on.
+  if (!is.null(counts)) {
+    d <- .efdr_join_counts(d, counts)                   # id-keyed (falls back to summed symbol)
+    d$K_eff <- .efdr_keff(d$K_ctrl, d$K_pert)
   } else {
-    z <- d$perturb_to_ctrl_shrunken_lfc / d$perturb_to_ctrl_shrunken_lfc_se
+    d$K_eff <- NA_real_
   }
   tibble::tibble(gene_short_name = d$gene_short_name, cell_group = d$cell_group,
-                 log_mean_expression = d$log_mean_expression, z = z) %>%
+                 log_mean_expression = d$log_mean_expression, z = d$z, K_eff = d$K_eff) %>%
     dplyr::filter(is.finite(.data$z))
 }
 
@@ -405,20 +443,17 @@ train_efdr_model <- function(null, detection = NULL, taus = .EFDR_TAUS,
             class = "efdr_model")
 }
 
-# Calibrate the honest effective degrees-of-freedom of the within-state contrast as a
-# function of the cell-weighted effective perturbation support (n_eff_pb). Naive Welch says
-# the df is (replicates - 1), but the trend-dispersion shrinkage borrows dispersion across
-# genes and buys real df back, so the effective df is higher. The null is the reference: at
-# moderate expression (isolating the sample-size effect from the low-expression artifact the
-# surface already prices), match the null |z| right-tail exceedance at `z0` to a
-# t-distribution and solve for its df. Returns a monotone (support -> df) lookup; NULL only
-# if the null has too few draws to calibrate (train_efdr_model then errors).
+# Calibrate the effective degrees-of-freedom of the within-state contrast as a function of the
+# effective count K_eff. The trend-dispersion shrinkage over-states precision on low-count
+# contrasts (near-zero genes, depleted cell types); the null is the reference for how much:
+# per K_eff octave, match the null |z| right-tail exceedance at `z0` to a t-distribution and
+# solve for its df. A low-K_eff contrast gets a low df (heavy tail); a well-counted one gets
+# ~normal. Returns a monotone (K_eff -> df) lookup; NULL only if the null has too few draws.
 .efdr_calibrate_df <- function(null, z0 = 3.5, min_n = 500L) {
-  d <- null[is.finite(null$n_eff_pb) & is.finite(null$z) &
-              is.finite(null$log_mean_expression) & null$log_mean_expression > -1, ]
+  d <- null[is.finite(null$K_eff) & is.finite(null$z), ]
   if (nrow(d) < min_n) return(NULL)
-  a <- abs(d$z); k <- d$n_eff_pb
-  kb <- round(k)                                        # bin continuous effective support to integer levels
+  a <- abs(d$z); k <- d$K_eff
+  kb <- round(log2(pmax(k, 0.5)))                       # bin effective count into log2 octaves
   solve_df <- function(p) {                              # 2*pt(-z0, df) is decreasing in df
     if (!is.finite(p) || p <= 2 * stats::pnorm(-z0)) return(Inf)  # normal already conservative
     g <- function(l) 2 * stats::pt(-z0, exp(l)) - p
@@ -426,10 +461,10 @@ train_efdr_model <- function(null, detection = NULL, taus = .EFDR_TAUS,
     if (g(log(1e4)) > 0) return(Inf)
     exp(stats::uniroot(g, c(log(0.5), log(1e4)))$root)
   }
-  levs <- sort(unique(kb[kb >= 2]))
-  rows <- lapply(levs, function(kk) {
-    ak <- a[kb == kk]; if (length(ak) < min_n) return(NULL)
-    data.frame(support = kk, df_eff = solve_df(mean(ak >= z0)), n = length(ak))
+  levs <- sort(unique(kb))
+  rows <- lapply(levs, function(lev) {
+    ak <- a[kb == lev]; if (length(ak) < min_n) return(NULL)
+    data.frame(support = 2^lev, df_eff = solve_df(mean(ak >= z0)), n = length(ak))
   })
   out <- do.call(rbind, rows)
   if (is.null(out) || nrow(out) < 2L) return(NULL)
@@ -483,7 +518,8 @@ train_efdr_model <- function(null, detection = NULL, taus = .EFDR_TAUS,
 #'     promote one.
 #' @export
 annotate_empirical_fdr_model <- function(model, deg_tbl, log_ratio, detection = NULL,
-                                         support = NULL, min_pseudobulks = .EFDR_MIN_PB,
+                                         support = NULL, counts = NULL,
+                                         min_pseudobulks = .EFDR_MIN_PB,
                                          group_col = "cell_group") {
   R <- model$ratios
   br <- if (log_ratio <= R[1]) list(lo = R[1], hi = R[1], w = 1) else
@@ -499,61 +535,47 @@ annotate_empirical_fdr_model <- function(model, deg_tbl, log_ratio, detection = 
     deg_tbl <- deg_tbl[, setdiff(names(deg_tbl), c("pct_emb", "pct_emb_pert")), drop = FALSE]
     deg_tbl <- dplyr::left_join(deg_tbl, detection, by = c("gene_short_name", "cell_group"))
   }
-  if (!is.null(support)) {
-    supp_cols <- intersect(c("n_pert_pb", "n_eff_pb", "n_ctrl_cells", "n_pert_cells"), names(support))
-    deg_tbl <- deg_tbl[, setdiff(names(deg_tbl), supp_cols), drop = FALSE]
-    deg_tbl <- dplyr::left_join(deg_tbl, support[, c("cell_group", supp_cols)], by = "cell_group")
+  if (!is.null(support)) {                                # n_pert_pb drives the <2-embryo gate
+    deg_tbl <- deg_tbl[, setdiff(names(deg_tbl), "n_pert_pb"), drop = FALSE]
+    deg_tbl <- dplyr::left_join(deg_tbl, support[, c("cell_group", "n_pert_pb")], by = "cell_group")
   }
-  if (!"n_ctrl_cells" %in% names(deg_tbl)) deg_tbl$n_ctrl_cells <- NA_real_
-  if (!"n_pert_cells" %in% names(deg_tbl)) deg_tbl$n_pert_cells <- NA_real_
-  # Map effective perturbation-arm support (n_eff_pb) -> honest effective df. Within the
-  # range the null covers, use the null-calibrated (support -> df) lookup (accounts for the
-  # shrinkage's df buy-back). BELOW the smallest calibrated support the control-split null
-  # has no coverage (its cell types are well-populated), so df is ramped analytically from a
-  # 0.5 floor at <=1 effective replicate up to the smallest calibrated df -- this is what
-  # demotes cell types that are thin *in cells* (n_eff -> 0), whose over-shrunk SE would
-  # otherwise manufacture a confident call.
+  if (!is.null(counts)) {                                 # per-(gene, cell_type) UMI totals -> K_eff
+    deg_tbl <- deg_tbl[, setdiff(names(deg_tbl), c("K_ctrl", "K_pert")), drop = FALSE]
+    deg_tbl <- .efdr_join_counts(deg_tbl, counts)         # id-keyed (falls back to summed symbol)
+  }
+  if (!"n_pert_pb" %in% names(deg_tbl)) deg_tbl$n_pert_pb <- NA_real_
+  if (!"K_ctrl" %in% names(deg_tbl)) deg_tbl$K_ctrl <- NA_real_
+  if (!"K_pert" %in% names(deg_tbl)) deg_tbl$K_pert <- NA_real_
+  # Map effective count K_eff -> honest df from the null calibration; below the smallest
+  # calibrated K_eff, ramp to a 0.5 floor as K_eff -> 0 (heavy tail). One count-support guard
+  # that subsumes the old cell-type df-correction and the SE floor.
   cal <- model$df_calib
-  s0 <- cal$support[1]; d0 <- cal$df_eff[1]              # smallest calibrated support and its df
-  dfmap <- function(n) {
-    out <- rep(NA_real_, length(n)); ok <- is.finite(n); nn <- n[ok]
-    idx <- findInterval(nn, cal$support)                 # within/above range: step lookup
+  s0 <- cal$support[1]; d0 <- cal$df_eff[1]              # smallest calibrated K_eff and its df
+  dfmap <- function(k) {
+    out <- rep(NA_real_, length(k)); ok <- is.finite(k); kk <- k[ok]
+    idx <- findInterval(kk, cal$support)                 # within/above range: step lookup
     val <- cal$df_eff[pmin(pmax(idx, 1L), nrow(cal))]
-    below <- nn < s0                                     # extend below the calibrated floor
-    val[below] <- if (s0 > 1) pmax(0.5, 0.5 + (d0 - 0.5) * (nn[below] - 1) / (s0 - 1)) else 0.5
+    below <- kk < s0                                     # extend below the calibrated floor
+    val[below] <- if (s0 > 0) pmax(0.5, 0.5 + (d0 - 0.5) * (kk[below] / s0)) else 0.5
     out[ok] <- val
     out
   }
 
   out <- deg_tbl %>%
     dplyr::mutate(
-      # SE-floored standardized statistic: cap the shrunken SE at the Poisson floor the counts
-      # support, so a near-zero gene can't get an insane |z| (same floor the null z got, so
-      # they stay on the same footing). Falls back to the raw z only if lfc/se/expression are
-      # absent (a caller that passed only `z`).
-      z = if (all(c("perturb_to_ctrl_shrunken_lfc", "perturb_to_ctrl_shrunken_lfc_se",
-                    "log_mean_expression") %in% names(.)))
-            .efdr_floored_z(.data$perturb_to_ctrl_shrunken_lfc, .data$perturb_to_ctrl_shrunken_lfc_se,
-                            .data$log_mean_expression, .data$n_ctrl_cells, .data$n_pert_cells)
-          else if ("z" %in% names(.)) .data$z
+      z = if ("z" %in% names(.)) .data$z
           else .data$perturb_to_ctrl_shrunken_lfc / .data$perturb_to_ctrl_shrunken_lfc_se,
       .dir = dplyr::if_else(.data$z < 0, "dn", "up"),
       .a = abs(.data$z),
-      # Ordinary reference p (the floor): the trusted ashr shrunken p if present, else
-      # normal(z). When perturbation-arm support is known, the ordinary test is made honest
-      # about the KO-arm degrees of freedom: a normal/ashr p assumes ~infinite df, but a
-      # contrast backed by few perturbation pseudobulks has finite (null-calibrated) df, so
-      # |z| is re-scored against a t-distribution. This demotes the cell-abundance confound
-      # (depleted cell types where the deep control arm lends unearned power) at the same
-      # decorate-in-place layer, with no DEG re-fit; it is a pure function of KO support, so
-      # it does not touch expression and cannot demote well-supported calls.
-      .df = dfmap(.data$n_eff_pb),
-      .p_df = dplyr::if_else(is.finite(.data$.df),
-                             2 * stats::pt(-.data$.a, df = pmax(.data$.df, 0.5)), NA_real_),
-      .ord_p = if ("perturb_to_ctrl_p_value" %in% names(.)) .data$perturb_to_ctrl_p_value
+      K_eff = .efdr_keff(.data$K_ctrl, .data$K_pert),
+      df_count = dfmap(.data$K_eff),
+      # p_ashr: ordinary shrunken significance (demote-only baseline; empirical can only demote).
+      p_ashr = if ("perturb_to_ctrl_p_value" %in% names(.)) .data$perturb_to_ctrl_p_value
                else 2 * (1 - stats::pnorm(.data$.a)),
-      # df-honesty is demote-only: never let the ordinary p be more confident than the t-test
-      .ord_p = dplyr::if_else(is.na(.data$.p_df), .data$.ord_p, pmax(.data$.ord_p, .data$.p_df)))
+      # p_count: the raw magnitude z scored against t(df(K_eff)) -- the count-support guard band
+      # (subsumes the cell-type df-correction and the SE floor). NA where counts are unavailable.
+      p_count = dplyr::if_else(is.finite(.data$df_count),
+                               2 * stats::pt(-.data$.a, df = pmax(.data$df_count, 0.5)), NA_real_))
 
   # 2-D empirical tail, interpolated across the two bracketing log-ratios.
   emp_tail <- rep(NA_real_, nrow(out))
@@ -568,18 +590,46 @@ annotate_empirical_fdr_model <- function(model, deg_tbl, log_ratio, detection = 
           .efdr_tail_2d(model$surf[[paste(d, br$hi)]], model$taus, model$egrid, model$pegrid, e, pe, a)
     emp_tail[idx] <- dplyr::coalesce(br$w * tl + (1 - br$w) * th, tl, th)
   }
-  # ashr floor, ALWAYS: demote-only. Where the tail is NA (missing surface or pct_emb),
-  # empirical_p is the ordinary p, so the floor still holds (no fallback hole).
-  emp_tail <- pmin(pmax(emp_tail, 0), 1)
-  out$empirical_p <- dplyr::if_else(is.na(emp_tail), out$.ord_p, pmax(emp_tail, out$.ord_p))
-  # Support gate: a cell type with fewer than `min_pseudobulks` perturbation pseudobulks
-  # has no valid two-group contrast (df < 1); its calls are uncallable, not significant.
+  out$p_tail <- pmin(pmax(emp_tail, 0), 1)               # control-sampling artifact floor
+  # empirical_p = max of the three demote-only floors: ashr (ordinary significance), tail
+  # (design-imbalance artifact), count (count-support guard). A call must clear all three; a
+  # missing tail/count drops out of the max (no fallback hole). All three are kept as columns.
+  out$empirical_p <- pmax(out$p_ashr,
+                          dplyr::coalesce(out$p_tail, 0),
+                          dplyr::coalesce(out$p_count, 0))
+  # Gate 1: a cell type with fewer than `min_pseudobulks` perturbation embryos has no valid
+  # two-group contrast; its calls are uncallable, not significant.
   gate <- is.finite(out$n_pert_pb) & out$n_pert_pb < min_pseudobulks
   out$empirical_p[gate] <- 1
+  # Gate 2 (gene absent from the cell type): a gene with ~zero total UMIs in BOTH arms is not
+  # expressed in this cell type at all, so any |z| it carries is pure trend-dispersion shrinkage
+  # noise (a near-zero gene assigned a floored SE) that no floor can price -- the control-split
+  # null never reaches such |z| at near-zero counts, and the count-t's heaviest tail cannot
+  # demote it. Gate ONLY when the larger arm is also empty: a well-counted control arm with an
+  # empty perturbation arm (K_ctrl large, K_pert = 0) is a genuine COMPLETE DEPLETION and MUST
+  # be kept. So the test is on max(K_ctrl, K_pert), not the harmonic-mean K_eff (which falls
+  # below 1 whenever either arm is empty, and would wrongly drop real depletions). Not an
+  # expression floor: it is "the gene has no counts in either arm of this cell type".
+  absent_gate <- is.finite(out$K_ctrl) & is.finite(out$K_pert) &
+    pmax(out$K_ctrl, out$K_pert) < .EFDR_MIN_ARM_UMI
+  out$empirical_p[absent_gate] <- 1
 
-  out %>%
+  # empirical_fdr: BH-adjust EACH floor within the cell group, then take the max q -- NOT
+  # BH(empirical_p). The per-gene max() floors every combined p near 1/nperm (some floor always
+  # sits at the permutation floor), compressing the p-distribution so BH crushes even real hits.
+  # Adjusting each floor in its own well-spread distribution lets the (often tiny) ashr q survive,
+  # while the gene must still clear all three q's -- the intersection of the three FDR-controlled
+  # call sets. Empirically ~2x the calls at fdr<=0.10 with no increase in the artifact rate. A
+  # missing tail/count -> 0 (non-constraining), matching the empirical_p max() semantics.
+  out <- out %>%
     dplyr::group_by(dplyr::across(all_of(group_col))) %>%
-    dplyr::mutate(empirical_fdr = stats::p.adjust(.data$empirical_p, "BH")) %>%
-    dplyr::ungroup() %>%
-    dplyr::select(-".dir", -".a", -".ord_p", -".df", -".p_df")
+    dplyr::mutate(
+      .q_ashr  = stats::p.adjust(pmax(.data$p_ashr, 0), "BH"),
+      .q_tail  = stats::p.adjust(dplyr::coalesce(.data$p_tail, 0), "BH"),
+      .q_count = stats::p.adjust(dplyr::coalesce(.data$p_count, 0), "BH"),
+      empirical_fdr = pmax(.data$.q_ashr, .data$.q_tail, .data$.q_count)) %>%
+    dplyr::ungroup()
+  out$empirical_fdr[out$empirical_p >= 1] <- 1           # gated (uncallable) genes: fdr = 1 too
+  out %>%
+    dplyr::select(-".dir", -".a", -".q_ashr", -".q_tail", -".q_count")  # keep p_ashr/p_tail/p_count/K_eff/df_count
 }


### PR DESCRIPTION
This branch adds count support as the third demote-only floor of the empirical-FDR model,
so `empirical_p = max(p_ashr, p_tail, p_count)` — a within-state DEG call is retained only
if it clears **all three**: ordinary shrinkage significance, the sampling-artifact tail,
and count support.

**The gap this closes.** The control-split tail prices the sampling artifact (which
embryos are drawn), but a second class of spurious calls survives it — calls whose
*counts* don't support the claimed precision. It has two faces that are one problem:

- **Cell-state depletion.** A depleted perturbation arm is nearly empty, yet the deep
  control arm supplies a tiny SE as if the contrast were well-powered → inflated,
  predominantly-down `|z|` (down:up rose from 1.4 in stable states to 12 in near-loss states).
- **Trend-dispersion over-confidence.** Variance shrinkage can drive the shrunken SE
  *below* what the counts support: a gene in <1% of cells gets a tighter SE than a
  broadly-expressed one, reporting a near-zero fold change at `|z|` 10–50. ashr can't fix
  this (it trusts the input SE), and the null inherits the same over-confidence.

**The fix — one mechanism keyed on the counts.** For each (gene, cell state) the two arms'
total UMI counts define an effective count
`K_eff = 1 / (1/(K_ctrl+κ) + 1/(K_pert+κ))`, κ=1 — the reciprocal of the Poisson
log-ratio variance (harmonic-mean count, dominated by the starved arm). The raw
`z = β̂/se` is scored against `t(df(K_eff))`, where df is **calibrated from the null's own
far tail per K_eff octave** (isotonic in K_eff, capped at 60 df, ramped to a heavy-tail
floor below the smallest octave). Low K_eff (depleted arm *or* globally near-zero gene) →
low df → heavy tail → demoted; well-counted → ≈normal → kept. Because it reads counts
**and** magnitude, it demotes an over-confident near-zero call without touching a
well-counted call of the same fold change — unlike a detection-only (Fisher) test, which
kills genuine large-effect calls that happen to be sparse.

This **supersedes** the intermediate approaches on this branch (the `n_eff` cell-weighted
df-correction and the theoretical SE floor, kept in history): one count-driven guard band
now subsumes both, at cell-state and per-gene granularity. It is a count-support guard
band ("can the counts support a between-arm difference at all"), deliberately agnostic to
nuisance covariates — a fine covariate df cost would need a nuisance-matched null (tracked
as a follow-up; GENE6 is unaffected since its DEG stage has `control_for_time=false`).

**Gene-absent gate.** The count-t's heaviest calibrated tail still can't fully demote the
most extreme residual: genes with ~zero UMIs in **both** arms that the shrinkage assigns a
large `|z|` (|z|≈33 on no data). These are not count-support artifacts the null can price
(control-splitting never reaches such `|z|` at near-zero counts, confirmed by direct null
exceedance), they are genes simply **absent from the cell type**. So a gate sets `p=1` when
`max(K_ctrl, K_pert) < 1` — no arm has even one UMI. Crucially it tests the **larger** arm,
not `K_eff`: a well-counted control arm with an empty perturbation arm (`K_ctrl` large,
`K_pert=0`) is a genuine **complete depletion** and is KEPT (e.g. grid1b in oligodendrocyte
precursor, z=−193, K_ctrl=10,355 — a call). This is the count-analog of the existing
≥2-pseudobulk gate, not an expression floor.

**Correctness — count join keyed on the feature id.** Arm counts are joined to the DEG (and
to the null draws) on the unique Ensembl `id` (= cds rownames), not `gene_short_name`, which
is one-to-many for multi-copy families (histones etc.) and silently duplicated DEG rows in
multi-perturbation runs. A shared `.efdr_join_counts` helper keys both the null and the real
DEG the same way, with a summed-symbol fallback when a table lacks `id`.

**Also in this branch (earlier commits):** cell-count-aware pseudobulk support collapsed to
one baked policy (no config knobs), and all support computation consolidated into
`efdr_support_from_coldata`.

**empirical_fdr = max of per-floor BH, not BH of the max.** BH-adjusting the per-gene
`empirical_p` (the max of the floors) is uselessly conservative: the max floors every gene's
combined p near `1/(nperm+1)`, compressing the distribution so BH crushes real hits (a
z=4.4 muscle gene lands at fdr≈0.19). Instead each floor is BH-adjusted in its own
distribution and the max q taken: `empirical_fdr = max(BH(p_ashr), BH(p_tail), BH(p_count))`,
gated genes forced to 1. A call still clears all three at the FDR level, but the tiny ashr q
survives. ~2x the calls at fdr≤0.10 with no rise in artifact rate. (`empirical_p` unchanged
as the per-gene foreground.) `nperm` is the complementary lever — production should use a
high `nperm` so `p_tail` isn't pinned at its floor.

**Diagnostics.** The decorated DEG table now retains `p_ashr`, `p_tail`, `p_count`,
`K_eff`, `df_count`, `K_ctrl`, `K_pert`, so any demotion is attributable to its cause.

**Validation (GENE6 myod1,six1a,six1b, fresh full null).** No row inflation (2,955,344
rows, dup=0). Among emp_p<0.05 GOI in reader-facing cell types (78,746) the clear-artifact
rate (near-empty arm) is ~1.4%, down from ~30%+; the demoted mass is artifact-enriched
(the DOWN·DEMOTED class = 52% of ordinary-significant calls is 97% near-empty-arm). max-BH
FDR gives 19,024 calls at fdr<=0.10 (0.3% artifact) vs ~1,500 under BH-of-max. Muscle
program recovered (mybphb/ckma clear FDR); real complete depletions preserved. Downstream
phenotyping is conservative: abundance unchanged, identity net −22 (BOR otic-placode +
kidney-PST controls intact), fitness net −3; the trimmed calls were artifact-driven fgsea
enrichments (e.g. adaxial "muscle contraction" built on late sarcomere markers absent from
PSM). nperm=1000 for validation; production should use nperm>=10000 for FDR resolution.
