### PR TITLE
Empirical-FDR: arm-matched null, minimum-cells gate, and gated-gene-aware phenotyping

### DIFF
--- a/R/empirical_fdr_model.R
+++ b/R/empirical_fdr_model.R
@@ -669,6 +669,26 @@ annotate_empirical_fdr_model <- function(model, deg_tbl, log_ratio = NULL, detec
       empirical_fdr = pmax(.data$.q_ashr, .data$.q_tail)) %>%
     dplyr::ungroup()
   out$empirical_fdr[out$empirical_p >= 1] <- 1           # gated (uncallable) genes: fdr = 1 too
-  out %>%
+  out <- out %>%
     dplyr::select(-".dir", -".a", -".thin_is_ko", -".q_ashr", -".q_tail")  # keep p_ashr/p_tail/thin_arm_cells/K_*
+  # Per-experiment efdr diagnostics (attached as an attribute so callers -- e.g. the mcclintock
+  # decorator stage -- can persist them; the located min-arm K in particular is otherwise only in
+  # the log). Counts are gate MEMBERSHIP (a call may satisfy more than one gate, so they need not sum).
+  attr(out, "efdr_stats") <- data.frame(
+    min_arm_cells_K       = as.integer(min_arm_cells),
+    p_ctrl_detection      = round(as.numeric(.p_det), 4),
+    det_pctl              = .EFDR_DET_PCTL,
+    n_calls               = nrow(out),
+    n_ashr_sig            = sum(out$p_ashr < 0.05, na.rm = TRUE),
+    n_retained            = sum(out$empirical_p < 0.05, na.rm = TRUE),
+    n_retained_down       = sum(out$empirical_p < 0.05 & out$z < 0, na.rm = TRUE),
+    n_retained_up         = sum(out$empirical_p < 0.05 & out$z > 0, na.rm = TRUE),
+    n_gate_lt2_pseudobulk = sum(gate, na.rm = TRUE),
+    n_gate_gene_absent    = sum(absent_gate, na.rm = TRUE),
+    n_gate_up_ctrl_absent = sum(up_absent_gate, na.rm = TRUE),
+    n_gate_up_empty_gain  = sum(up_empty_gain_gate, na.rm = TRUE),
+    n_gate_low_ctrl_det   = sum(low_src_det_gate, na.rm = TRUE),
+    n_gate_min_arm_cells  = sum(min_arm_gate, na.rm = TRUE),
+    stringsAsFactors = FALSE)
+  out
 }

--- a/R/empirical_fdr_model.R
+++ b/R/empirical_fdr_model.R
@@ -55,14 +55,21 @@ NULL
                       # calls, because real GAINS can be sparse (phox2a is a real up-call at 0.7%
                       # perturbation detection), so no analogous gap exists on the up side; up-blips
                       # are handled by the thin-gain (arm-size) gate instead.
-.EFDR_MIN_GAIN_CELLS <- 25L  # a GAIN (gene higher in the thinner arm) needs at least this many
-                      # cells in that arm to be callable. The control-split null structurally
-                      # cannot produce a thin-arm gain (a thin pseudo-arm can only LOSE genes it
-                      # doesn't carry, never gain one), so its up-tail is uninformative at thin
-                      # arms and would keep every few-cell up-blip at p_tail ~ 0.001. This is the
-                      # up-direction analog of the <2-pseudobulk gate: too few gaining-arm cells
-                      # to support an increase -> uncallable. (Losses are unaffected -- the null
-                      # DOES generate thin-arm losses, so the down-tail prices them.)
+# --- Minimum trustworthy cells in the THINNER arm (both directions), LOCATED PER EXPERIMENT ---
+# A complete absence of a gene in the thin arm is a real depletion only if that arm had enough cells
+# to have detected it; below the floor the arm is too thin to make any call (e.g. brd1b in a cell type
+# depleted to 8 perturbation cells, none expressing -- a too-few-cells call, not a loss). Keyed on
+# min(n_ctrl_cells, n_pert_cells) -- the arm CELL count, NOT detection or the control:perturbation
+# ratio (unreliable for rare cell types). The floor VALUE is located per experiment by a Poisson
+# power argument (used only to place the gate, not as a per-call test): a well-detected gene (the
+# .EFDR_DET_PCTL-th percentile of control detection, p) is expected in .EFDR_MIN_EXPECTED cells once
+# the arm holds .EFDR_MIN_EXPECTED / p cells, so below that a complete absence can't be told from
+# undersampling. K = ceil(.EFDR_MIN_EXPECTED / p). Self-adjusts to capture depth (a shallow run with
+# lower detection -> higher floor). Also subsumes the old up-only thin-gain gate (the control-split
+# null cannot generate a thin-arm GAIN, so the same cell floor covers both directions).
+.EFDR_MIN_EXPECTED  <- 3     # expected expressing cells for a callable complete absence (Poisson P(0)=0.05)
+.EFDR_DET_PCTL      <- 0.75  # reference control-detection percentile (a "well-detected" gene)
+.EFDR_MIN_ARM_CELLS <- 25L   # fallback floor if the detection distribution is degenerate (e.g. GENE6 locates 27)
 
 #' Build a control-split empirical null for the DEG artifact.
 #'
@@ -627,16 +634,28 @@ annotate_empirical_fdr_model <- function(model, deg_tbl, log_ratio = NULL, detec
   out$det_ctrl <- out$n_expr_ctrl / out$n_ctrl_cells
   low_src_det_gate <- (out$z < 0) & is.finite(out$det_ctrl) & (out$det_ctrl < .EFDR_MIN_SRC_DET)
   out$empirical_p[low_src_det_gate] <- 1
-  # Gate 4 (thin-arm GAIN): a gene called higher in the THINNER arm (.dir == "up" relative to that
-  # arm) when that arm carries < MIN_GAIN_CELLS cells is uncallable. The control-split null cannot
-  # generate a thin-arm gain, so p_tail is structurally light there (~0.001) and would keep every
-  # few-cell up-blip; the tail prices losses (which the null DOES generate) but not gains, so gains
-  # need this explicit sampling floor -- the up analog of the <2-pseudobulk gate. Direction is
-  # relative to the thin arm, so it generalizes: control-heavy gates thin-KO-arm up-regulation;
-  # perturbation-heavy gates thin-control-arm apparent-gains.
-  thin_gain_gate <- out$.dir == "up" & is.finite(out$thin_arm_cells) &
-    out$thin_arm_cells < .EFDR_MIN_GAIN_CELLS
-  out$empirical_p[thin_gain_gate] <- 1
+  # Gate 4 (minimum cells in the thinner arm, BOTH directions): a contrast whose thinner arm holds
+  # fewer than MIN_ARM_CELLS cells is uncallable regardless of expression or direction. A complete
+  # absence of the gene in the thin arm is a real depletion ONLY if that arm had enough cells to have
+  # detected the gene -- e.g. brd1b in a cell type depleted to 8 perturbation cells (none expressing)
+  # is a too-few-cells call, not a loss. Gated on the CELL COUNT of the thinner arm only, NOT on
+  # detection or the control:perturbation ratio (which is unreliable for rare cell types), so it is
+  # robust for rare cell types and does not try to price sub-floor arms in the null (which cannot
+  # simulate a thin arm against a very deep control arm anyway). Being symmetric, it also subsumes the
+  # old up-only thin-gain gate: the control-split null structurally cannot generate a thin-arm GAIN,
+  # and the same cell floor covers that. The floor value is LOCATED per experiment by the Poisson
+  # power argument above (constants .EFDR_MIN_EXPECTED / .EFDR_DET_PCTL): a well-detected gene (p =
+  # .EFDR_DET_PCTL-th percentile of positive control detection) needs 3/p thin-arm cells before a
+  # complete absence is distinguishable from undersampling. Falls back to .EFDR_MIN_ARM_CELLS if the
+  # detection distribution is degenerate.
+  .p_det <- suppressWarnings(stats::quantile(
+    out$det_ctrl[is.finite(out$det_ctrl) & out$det_ctrl > 0], .EFDR_DET_PCTL, names = FALSE))
+  min_arm_cells <- if (is.finite(.p_det) && .p_det > 0)
+    as.integer(ceiling(.EFDR_MIN_EXPECTED / .p_det)) else .EFDR_MIN_ARM_CELLS
+  message(sprintf("[efdr] min-arm-cell floor located at K=%d (p%.0f control detection = %.3f)",
+                  min_arm_cells, 100 * .EFDR_DET_PCTL, .p_det))
+  min_arm_gate <- is.finite(out$thin_arm_cells) & (out$thin_arm_cells < min_arm_cells)
+  out$empirical_p[min_arm_gate] <- 1
 
   # empirical_fdr: BH-adjust EACH floor within the cell group, then take the max q -- NOT
   # BH(empirical_p) (the per-gene max compresses the p-distribution so BH crushes real hits).

--- a/R/phenotype_assignment_utils.R
+++ b/R/phenotype_assignment_utils.R
@@ -19,17 +19,24 @@ make_rank <- function(deg_tbl,
         transmute(
             gene = .data[[gene_col]] %>% as.character(),
             logFC = as.numeric(.data[[logFC_col]]),
-            w = if (use_weight) {
-                p <- as.numeric(.data[[weight_col]])
-                1 - pmin(pmax(replace(p, !is.finite(p), 0), 0), 1)
-            } else {
-                1
-            }
+            p = if (use_weight) as.numeric(.data[[weight_col]]) else NA_real_
         ) %>%
         distinct(gene, .keep_all = TRUE) %>%
         filter(is.finite(logFC))
-    # Rank by the model-weighted statistic (logFC * (1 - empirical_p)); with no
-    # weight column this reduces to the shrunken logFC.
+    if (use_weight) {
+        # EXCLUDE gated (uncallable) genes -- empirical_p == 1 -- from the preranked list entirely,
+        # rather than letting the (1 - empirical_p) weight collapse them to rank 0 in the MIDDLE. Under
+        # heavy, asymmetric gating (e.g. the min-arm-cell gate demoting far more down- than up-calls),
+        # a large mid-list block of zeros unbalances the ranking and manufactures spurious
+        # one-directional GSEA enrichments (up-regulated fitness sets -- apoptosis/stress). Callable
+        # genes keep the soft model weight (1 - empirical_p); NA weights are treated as un-demoted.
+        x <- x %>% filter(!is.finite(.data$p) | .data$p < 1)
+        x$w <- 1 - pmin(pmax(replace(x$p, !is.finite(x$p), 0), 0), 1)
+    } else {
+        x$w <- 1
+    }
+    # Rank by the model-weighted statistic (logFC * (1 - empirical_p)) over the CALLABLE genes; with
+    # no weight column this reduces to the shrunken logFC over all genes.
     r <- x$logFC * x$w
     names(r) <- x$gene
     sort(r, decreasing = TRUE)


### PR DESCRIPTION
Replaces the count-calibrated t (which crushed real loss-of-function signal) with a per-experiment empirical-FDR model conditioned on **how thin the arm carrying the change is** — the true driver of the control-sampling artifact (Amy's flagged artifacts and confirmed real calls overlap completely in expression). All in `R/empirical_fdr_model.R` + `R/phenotype_assignment_utils.R`; decorate-in-place, no GLM re-fit.

### The model
- **`build_empirical_null`**: control-split grid thin-extended to a valid ≥2-embryo pseudobulk (~3%, three points); records per-cell-type pseudo-arm cell counts + expressing-cell counts (id-keyed).
- **`train_efdr_model`**: local-empirical tail grid over (expression × log10 thin-arm cells) per direction — replaces the scam surface, which under-fit the low-expression/thin-arm corner.
- **`annotate_empirical_fdr_model`**: `empirical_p = max(p_ashr, p_tail)`; `empirical_fdr = max(BH(p_ashr), BH(p_tail))`. Count-t `p_count` removed; `K_eff` kept as a diagnostic only.

### Uncallability gates (empirical_p = 1; none an a-priori expression floor)
1. **<2 KO pseudobulks** — no valid contrast.
2. **Gene-absent / empty high arm** — `max(K_ctrl,K_pert)<1`, + up mirrors: up-call with empty control (`K_ctrl<1`) or empty **gaining** arm (`K_pert<1`, the 5S_rRNA `n_expr_pert=0` leak).
3. **Low control-detection loss** (down) — baseline detected in <2% of control cells (data-derived).
4. **Minimum cells in the thinner arm** (both directions) — `min(n_ctrl,n_pert) < K`. A complete absence is a real depletion only if the arm had enough cells to have seen the gene; the GLM can't flag this (an all-zero arm's raw SE collapses to ~0.3 regardless of cell count — a separation pathology ashr never crushes), so the cell count is the only signal. **K located per experiment** by a Poisson power argument (used only to place the gate): `K = ceil(3 / p75)`, p75 = 75th-pct control detection → **27 on GENE6**; self-adjusts to depth. Subsumes the old up-only thin-gain gate.

### Phenotyping: exclude gated genes from the fgsea ranking
`make_rank` ranked by `logFC × (1 − empirical_p)`, so gated genes collapsed to rank 0 (the middle). Under heavy asymmetric down-gating this unbalanced the preranked list and manufactured spurious up-regulated fitness enrichments (apoptosis 2→51 on GENE6). Fix: drop gated genes (`empirical_p == 1`) from the ranking entirely; callable genes keep the soft weight. With the fix the min-arm gate is a clean scrub — fitness net −4, zero manufactured apoptosis, identity a reshuffle.

### Diagnostics
`annotate` attaches an `efdr_stats` attribute (located K, detection percentile, per-gate counts, retained/demoted tallies) for downstream persistence.

### Validation (GENE6 myod1/six1a/six1b, vs Amy's hand review)
- **10/10** flagged artifacts gated; **9/11** confirmed reals kept (phox2a and the myog `z=−24.8` depletion both kept).
- Held-out calibration: naive FPR 16% → ~5% at the low-expression floor.
- Whole-run: **77.3% demoted / 22.7% retained**; real-biology corner (deep arm, high expr) ~0% demoted.
