### PR TITLE
collect_cell_loss_explanations: carry effect_type autonomy tag

### DIFF
--- a/R/narrative.R
+++ b/R/narrative.R
@@ -1187,6 +1187,13 @@ summarize_impact_in_lineage_context <- function(
 }
 
 collect_cell_loss_explanations <- function(explanations_df) {
+  # Carry each cell type's autonomy classification into the per-cell block so the
+  # downstream per-tissue synthesis can weight cell-autonomous cells and treat
+  # non-autonomous (secondary) cells collectively. Guard for callers whose frame
+  # predates the effect_type column.
+  if (!"effect_type" %in% names(explanations_df)) {
+    explanations_df$effect_type <- NA_character_
+  }
   explanations_df %>%
     rowwise() %>%
     mutate(
@@ -1214,6 +1221,7 @@ collect_cell_loss_explanations <- function(explanations_df) {
       },
       explanation = paste(
         "Cell type:", cell_type,
+        if (!is.na(effect_type) && nzchar(effect_type)) paste0(" [", effect_type, "]") else "",
         "\nSummary:", llm_summary,
         "\nDisrupted pathways:\n", pathway_explanations,
         "---------------------\n"


### PR DESCRIPTION
## Carry cell-autonomy (effect_type) into the per-tissue summary input

Follow-up to the merged `dact-expectation-citations` work (#36), for Amy's review of the gene6 impact table. To let the per-tissue synthesis discriminate direct targets from secondary effects, the per-cell explanations it consumes must carry the autonomy classification.

### Change
- `collect_cell_loss_explanations()` now tags each per-cell block with `[Cell-autonomous]` or `[Non-autonomous]` (from `effect_type`). Guarded for callers whose frame predates the `effect_type` column.

This is what the companion `cell_loss_mechanisms` v4 prompt (zscapeaitools) reads to weight cell-autonomous cells and treat non-autonomous cells collectively.

### Companion PRs
- zscapeaitools: `cell_type_impact` v16 + `cell_loss_mechanisms` v4 → `main`
- mcclintock: `strip_empty_pmid` on all summaries → `develop`
