### PR TITLE
One gate policy for every experiment: per-call power, replication, embryos

### DIFF
--- a/R/empirical_fdr_model.R
+++ b/R/empirical_fdr_model.R
@@ -53,23 +53,72 @@ NULL
                       # Amy's confirmed 'too low' down-artifacts all at <=1.1%, with a clean ~10x gap;
                       # 2% sits in that gap. DIRECTIONAL (control arm, down only) -- NOT applied to up
                       # calls, because real GAINS can be sparse (phox2a is a real up-call at 0.7%
-                      # perturbation detection), so no analogous gap exists on the up side; up-blips
-                      # are handled by the thin-gain (arm-size) gate instead.
-# --- Minimum trustworthy cells in the THINNER arm (both directions), LOCATED PER EXPERIMENT ---
-# A complete absence of a gene in the thin arm is a real depletion only if that arm had enough cells
-# to have detected it; below the floor the arm is too thin to make any call (e.g. brd1b in a cell type
-# depleted to 8 perturbation cells, none expressing -- a too-few-cells call, not a loss). Keyed on
-# min(n_ctrl_cells, n_pert_cells) -- the arm CELL count, NOT detection or the control:perturbation
-# ratio (unreliable for rare cell types). The floor VALUE is located per experiment by a Poisson
-# power argument (used only to place the gate, not as a per-call test): a well-detected gene (the
-# .EFDR_DET_PCTL-th percentile of control detection, p) is expected in .EFDR_MIN_EXPECTED cells once
-# the arm holds .EFDR_MIN_EXPECTED / p cells, so below that a complete absence can't be told from
-# undersampling. K = ceil(.EFDR_MIN_EXPECTED / p). Self-adjusts to capture depth (a shallow run with
-# lower detection -> higher floor). Also subsumes the old up-only thin-gain gate (the control-split
-# null cannot generate a thin-arm GAIN, so the same cell floor covers both directions).
-.EFDR_MIN_EXPECTED  <- 3     # expected expressing cells for a callable complete absence (Poisson P(0)=0.05)
-.EFDR_DET_PCTL      <- 0.75  # reference control-detection percentile (a "well-detected" gene)
-.EFDR_MIN_ARM_CELLS <- 25L   # fallback floor if the detection distribution is degenerate (e.g. GENE6 locates 27)
+                      # perturbation detection), so no analogous gap exists on the up side.
+                      # OFF by default; see .EFDR_DEFAULT_GATES.
+# --- Is the thinner arm powered to see THIS gene? (per call, both directions) -----------------
+# A reduced-or-absent signal in the thinner arm is only callable if that arm held enough cells to
+# have detected the gene in the first place. If a gene is detected in a fraction p of cells, an arm
+# of n cells is expected to show it in n*p of them; at n*p = .EFDR_MIN_EXPECTED the Poisson chance
+# of seeing none is exp(-3) ~ 5%, so below that "we saw none" is not distinguishable from "we did
+# not sample it". The test is therefore expected detections >= .EFDR_MIN_EXPECTED, where
+#
+#     expected = min(n_ctrl_cells, n_pert_cells) * max(det_ctrl, det_pert)
+#
+# p is read as the MAX of the two arms' detection rates: whichever arm carries the gene supplies
+# the rate (that arm is well sampled, so the rate is well estimated), and the thinner arm supplies
+# only its cell COUNT, which is exact. Taking the max rather than the other arm's rate is what
+# keeps a gain from a zero baseline testable -- the reference arm's rate would be 0 there.
+#
+# This REPLACES a flat per-experiment cell floor K = ceil(3 / p75(det_ctrl)). That floor asked only
+# "how many cells are in this arm", so it discarded every gene in a small cell type regardless of
+# expression, while waving through trace genes in large ones. It also inherited two underivable
+# constants: the .75 percentile, and the notion of a single reference "well-detected" gene standing
+# in for all of them. The per-call form keeps only .EFDR_MIN_EXPECTED, the one constant with a
+# derivation. The K machinery is retained below solely so the old policy stays reproducible via
+# `gates` for back-comparison.
+.EFDR_MIN_EXPECTED  <- 3     # expected detections needed in the thinner arm (Poisson P(0)=0.05)
+.EFDR_DET_PCTL      <- 0.75  # legacy: percentile locating the retired flat cell floor K
+.EFDR_MIN_ARM_CELLS <- 25L   # legacy: fallback for K if the detection distribution is degenerate
+
+# Every uncallability gate that exists, in the order it is applied. Every one pins empirical_p
+# to 1. Which SUBSET runs is chosen by `gates` (see annotate_empirical_fdr_model); the default
+# is .EFDR_DEFAULT_GATES below. Names are the stable public identifiers -- the config, the CLI
+# and the diagnostics table all use these strings.
+.EFDR_GATES <- c("not_replicated",         # detected in <min_replicate_embryos embryos in BOTH arms
+                 "too_few_embryos",        # <2 perturbation embryos: no valid two-group contrast
+                 "not_detected_anywhere",  # ~0 UMI in BOTH arms: any |z| is shrinkage noise
+                 "gain_from_zero",         # UP call whose CONTROL arm has ~0 UMI
+                 "gain_no_counts",         # UP call whose PERTURBATION (gaining) arm has ~0 UMI
+                 "loss_from_trace",        # DOWN call detected in <MIN_SRC_DET of control cells
+                 "too_few_cells",          # thinner arm not powered to see THIS gene (expected < 3)
+                 "flat_cell_floor")        # legacy: thinner arm below the per-experiment floor K
+
+# The gates applied unless a caller says otherwise -- three rules.
+#
+#   too_few_embryos  <2 perturbation embryos: no two-group contrast exists.
+#   not_replicated   the gene was seen in <min_replicate_embryos distinct embryos in BOTH arms,
+#                    i.e. it was never observed more than once anywhere.
+#   too_few_cells    the thinner arm was not powered to see this gene (see .EFDR_MIN_EXPECTED).
+#
+# The previous policy's other five gates are off by default, each subsumed:
+#   not_detected_anywhere  a gene in >=2 embryos of either arm necessarily has counts somewhere.
+#   gain_from_zero         an absolute "control arm has 0 UMI" rule that could not tell one stray
+#                          cell from sixteen, so it removed real ectopic activation on low-depth
+#                          runs; the expected-detections test answers that question directly.
+#   gain_no_counts         measured to remove ZERO otherwise-significant calls in all six test
+#                          experiments once too_few_cells applies everywhere (it fires on up to
+#                          10% of calls but never on one that would have survived).
+#   flat_cell_floor        the retired per-experiment cell floor K; see .EFDR_MIN_EXPECTED above.
+#   loss_from_trace        a flat 2% control-detection floor. Removed calls well replicated across
+#                          20+ embryos purely for being lowly expressed, and 64-82% of what it
+#                          uniquely removed is caught by expected detections on a derived quantity.
+#
+# All five remain selectable, so the previous policy is reproducible for back-comparison:
+#   gates = c("too_few_embryos", "not_detected_anywhere", "gain_from_zero", "gain_no_counts",
+#             "loss_from_trace", "flat_cell_floor")
+.EFDR_DEFAULT_GATES <- c("too_few_embryos", "not_replicated", "too_few_cells")
+
+.EFDR_MIN_REP_EMB <- 2L
 
 #' Build a control-split empirical null for the DEG artifact.
 #'
@@ -222,12 +271,35 @@ build_empirical_null <- function(cds,
   # subsequent matmul + as.matrix() (silently comes out NA), the same class of problem
   # efdr_detection_rate()'s .rate() helper already coerces around above. Doing it once here
   # also avoids materializing exprs(cds) twice (once for S, once for D).
-  M <- methods::as(monocle3::exprs(cds), "dgCMatrix")
+  # drop0: a materialized BPCells matrix can carry EXPLICIT ZEROS in its sparsity pattern
+  # (4.65% of stored entries in GENE8's contrast_cds; 0% in SGSeq2's). The binarisation below
+  # sets every STORED entry to 1, so without dropping them a stored zero counts as a cell
+  # expressing the gene -- inflating n_expr_* and hence det_ctrl, which drives the
+  # low-source-detection gate, and n_emb_*. Symptom in a decorated table: K_ctrl < n_expr_ctrl,
+  # arithmetically impossible, in 19.6% of rows of GENE8 gata5 as shipped.
+  M <- Matrix::drop0(methods::as(monocle3::exprs(cds), "dgCMatrix"))
   S <- as.matrix(M %*% ind)                              # genes x (cell_type|arm) raw UMI totals
   # cells expressing the gene per (gene, cell_type|arm) -- binarized matmul, same grouping. Feeds
   # the per-arm DETECTION (expressing cells / arm cells) used by the down-call source-detection gate.
   Db <- M; Db@x[] <- 1                                   # binarise (stored entries are always > 0 for counts)
   D <- as.matrix(Db %*% ind)                             # genes x (cell_type|arm) cells expressing
+  # Distinct EMBRYOS detecting the gene per (gene, cell_type|arm) -- the replicate-level count the
+  # `not_replicated` gate needs. Accumulated one embryo at a time and kept sparse: the direct
+  # route (grouping by cell_type|arm|embryo in one matmul) is genes x ~C*2*E, which densifies to
+  # GBs on a full run. Per embryo the product is genes x (cell_type|arm), binarised to "this embryo
+  # saw it" and summed, so the accumulator never leaves the size of D.
+  smp <- as.character(cd[[sample_group]])
+  Nemb <- matrix(0L, nrow(M), nlevels(grp))              # genes x (cell_type|arm), dense int
+  for (s in unique(smp)) {
+    k <- which(smp == s)
+    Gs <- Matrix::sparseMatrix(i = seq_along(k), j = as.integer(grp[k]), x = 1,
+                               dims = c(length(k), nlevels(grp)))
+    Xs <- methods::as(Db[, k, drop = FALSE] %*% Gs, "TsparseMatrix")
+    # +1 only on the (gene, arm) entries this embryo touched: O(nnz) per embryo rather than a
+    # whole-matrix add, which is what makes ~500 embryos affordable.
+    ij <- cbind(Xs@i + 1L, Xs@j + 1L)
+    Nemb[ij] <- Nemb[ij] + 1L
+  }
   ids <- rownames(cds)
   gsym <- SummarizedExperiment::rowData(cds)$gene_short_name
   if (is.null(gsym)) gsym <- ids
@@ -241,7 +313,9 @@ build_empirical_null <- function(cds,
                K_ctrl = if (length(jc)) S[, jc] else 0,
                K_pert = if (length(jp)) S[, jp] else 0,
                n_expr_ctrl = if (length(jc)) D[, jc] else 0,
-               n_expr_pert = if (length(jp)) D[, jp] else 0, stringsAsFactors = FALSE)
+               n_expr_pert = if (length(jp)) D[, jp] else 0,
+               n_emb_ctrl = if (length(jc)) Nemb[, jc] else 0,
+               n_emb_pert = if (length(jp)) Nemb[, jp] else 0, stringsAsFactors = FALSE)
   })
   do.call(rbind, res)
 }
@@ -252,16 +326,24 @@ build_empirical_null <- function(cds,
 # computed the same way on both sides.
 .efdr_join_counts <- function(x, counts) {
   has_det <- all(c("n_expr_ctrl", "n_expr_pert") %in% names(counts))
+  has_emb <- all(c("n_emb_ctrl", "n_emb_pert") %in% names(counts))
   if ("id" %in% names(x) && "id" %in% names(counts)) {
     cols <- c("id", "cell_group", "K_ctrl", "K_pert",
-              if (has_det) c("n_expr_ctrl", "n_expr_pert"))
+              if (has_det) c("n_expr_ctrl", "n_expr_pert"),
+              if (has_emb) c("n_emb_ctrl", "n_emb_pert"))
     dplyr::left_join(x, counts[, cols], by = c("id", "cell_group"))
   } else {
+    # gene_short_name fallback: UMI and cell counts SUM across a symbol's ids, but embryo counts
+    # cannot -- the same embryo can detect two ids of one symbol, so summing double-counts the
+    # replicate. max() is the honest bound available without the per-embryo detail (it is the
+    # count for the single best-detected id, so it never overstates the number of distinct embryos).
     cnt <- counts %>%
       dplyr::group_by(.data$gene_short_name, .data$cell_group) %>%
       dplyr::summarise(K_ctrl = sum(.data$K_ctrl), K_pert = sum(.data$K_pert),
                        n_expr_ctrl = if (has_det) sum(.data$n_expr_ctrl) else NA_real_,
                        n_expr_pert = if (has_det) sum(.data$n_expr_pert) else NA_real_,
+                       n_emb_ctrl  = if (has_emb) max(.data$n_emb_ctrl)  else NA_real_,
+                       n_emb_pert  = if (has_emb) max(.data$n_emb_pert)  else NA_real_,
                        .groups = "drop")
     dplyr::left_join(x, cnt, by = c("gene_short_name", "cell_group"))
   }
@@ -536,6 +618,20 @@ train_efdr_model <- function(null, detection = NULL, taus = .EFDR_TAUS,
 #' @param detection Deprecated / unused (the %embryos covariate is retired).
 #' @param log_ratio Deprecated / ignored (the tail is conditioned on the actual
 #'   per-cell-type arm cell count, not a single global sampling ratio).
+#' @param gates Character vector of the uncallability gates to APPLY, from
+#'   `.EFDR_GATES`. Defaults to `.EFDR_DEFAULT_GATES` = `too_few_embryos`,
+#'   `not_replicated`, `too_few_cells`. The previous policy's other five gates
+#'   (`not_detected_anywhere`, `gain_from_zero`, `gain_no_counts`,
+#'   `loss_from_trace`, and `flat_cell_floor`, the retired per-experiment cell
+#'   floor K) are off by default because each is subsumed; pass them explicitly
+#'   to reproduce that policy for back-comparison. Gates not listed are still
+#'   computed and counted in the `efdr_stats` attribute -- they just stop pinning
+#'   `empirical_p` to 1, so those calls fall back to the two statistical floors
+#'   (`max(p_ashr, p_tail)`). Unknown names error rather than silently no-op.
+#' @param min_replicate_embryos Distinct embryos that must detect the gene in at
+#'   least one arm for the `not_replicated` gate to pass it (default
+#'   `.EFDR_MIN_REP_EMB` = 2). Needs `counts` to carry `n_emb_ctrl` / `n_emb_pert`
+#'   (produced by `.efdr_arm_counts`); without them nothing is gated on this axis.
 #' @param group_col Column to BH-adjust within (default `cell_group`).
 #' @return `deg_tbl` with added `empirical_p` and `empirical_fdr`.
 #' @details The tail null is conditioned on **expression x thin-arm cell count**
@@ -549,7 +645,18 @@ train_efdr_model <- function(null, detection = NULL, taus = .EFDR_TAUS,
 annotate_empirical_fdr_model <- function(model, deg_tbl, log_ratio = NULL, detection = NULL,
                                          support = NULL, counts = NULL, arm_cells = NULL,
                                          min_pseudobulks = .EFDR_MIN_PB,
+                                         gates = .EFDR_DEFAULT_GATES,
+                                         min_replicate_embryos = .EFDR_MIN_REP_EMB,
                                          group_col = "cell_group") {
+  gates <- setdiff(as.character(gates), c("", NA_character_))
+  if (length(bad <- setdiff(gates, .EFDR_GATES)))
+    stop("unknown gate(s): ", paste(bad, collapse = ", "),
+         ". Valid: ", paste(.EFDR_GATES, collapse = ", "))
+  # Gates are always COMPUTED (the diagnostics report membership either way); `on()` decides
+  # whether a gate is APPLIED to empirical_p.
+  on <- function(g) g %in% gates
+  message(sprintf("[efdr] gates applied: %s (min_replicate_embryos=%d)",
+                  paste(gates, collapse = ", "), as.integer(min_replicate_embryos)))
   # (Re)join the per-cell-type inputs, dropping any stale copies first so re-decoration
   # of an already-decorated table doesn't collide into `.x`/`.y` and silently NA a covariate.
   if (!is.null(support)) {                                # n_pert_pb -> <2-embryo gate
@@ -561,7 +668,8 @@ annotate_empirical_fdr_model <- function(model, deg_tbl, log_ratio = NULL, detec
     # when `counts` carries them): re-decorating an already-arm-matched-decorated table
     # otherwise collides into n_expr_ctrl.x/.y (dplyr's duplicate-column suffixing), and
     # det_ctrl's later reference to the plain column name silently resolves to nothing.
-    deg_tbl <- deg_tbl[, setdiff(names(deg_tbl), c("K_ctrl", "K_pert", "n_expr_ctrl", "n_expr_pert")), drop = FALSE]
+    deg_tbl <- deg_tbl[, setdiff(names(deg_tbl), c("K_ctrl", "K_pert", "n_expr_ctrl", "n_expr_pert",
+                                                   "n_emb_ctrl", "n_emb_pert")), drop = FALSE]
     deg_tbl <- .efdr_join_counts(deg_tbl, counts)         # id-keyed (falls back to summed symbol)
   }
   if (!is.null(arm_cells)) {                              # per-cell-type arm CELL counts -> tail axis
@@ -570,7 +678,7 @@ annotate_empirical_fdr_model <- function(model, deg_tbl, log_ratio = NULL, detec
                                 by = "cell_group")
   }
   for (col in c("n_pert_pb", "K_ctrl", "K_pert", "n_ctrl_cells", "n_pert_cells",
-                "n_expr_ctrl", "n_expr_pert"))
+                "n_expr_ctrl", "n_expr_pert", "n_emb_ctrl", "n_emb_pert"))
     if (!col %in% names(deg_tbl)) deg_tbl[[col]] <- NA_real_
 
   out <- deg_tbl %>%
@@ -606,23 +714,34 @@ annotate_empirical_fdr_model <- function(model, deg_tbl, log_ratio = NULL, detec
   # (thin-arm artifact). A missing tail drops out of the max (no fallback hole).
   out$empirical_p <- pmax(out$p_ashr, dplyr::coalesce(out$p_tail, 0))
 
+  # REPLICABILITY (not_replicated): the gene must have been seen in at least
+  # `min_replicate_embryos` distinct embryos of AT LEAST ONE arm. At ~500 UMI/cell most genes
+  # are absent from any given cell, so catching the same gene in two separate specimens of one
+  # arm and none of the other is not a coincidence the sampling produces easily -- which is
+  # exactly what the arm-matched null prices, and why this is a better instrument than the
+  # absolute zero-UMI rules it replaces. Direction-agnostic and arm-agnostic on purpose: it
+  # asks "is this gene really measured in this cell type at all", not "which way did it move".
+  # NA counts (no `counts` input) -> not gated, matching every other count-driven gate.
+  out$max_emb_det <- pmax(out$n_emb_ctrl, out$n_emb_pert, na.rm = TRUE)
+  not_replicated_gate <- is.finite(out$max_emb_det) & out$max_emb_det < min_replicate_embryos
+  if (on("not_replicated")) out$empirical_p[not_replicated_gate] <- 1
   # Gate 1 (<2 perturbation embryos): no valid two-group contrast; calls uncallable.
   gate <- is.finite(out$n_pert_pb) & out$n_pert_pb < min_pseudobulks
-  out$empirical_p[gate] <- 1
+  if (on("too_few_embryos")) out$empirical_p[gate] <- 1
   # Gate 2 (gene absent from the cell type): ~zero UMIs in BOTH arms -> not expressed here at all;
   # any |z| is pure shrinkage noise no floor can price. Gate only when the LARGER arm is empty
   # (max(K)), so a deep control arm with an empty perturbation arm = genuine COMPLETE DEPLETION is
   # KEPT. Not an expression floor: "the gene has no counts in either arm of this cell type".
   absent_gate <- is.finite(out$K_ctrl) & is.finite(out$K_pert) &
     pmax(out$K_ctrl, out$K_pert) < .EFDR_MIN_ARM_UMI
-  out$empirical_p[absent_gate] <- 1
+  if (on("not_detected_anywhere")) out$empirical_p[absent_gate] <- 1
   # Gate 3 (control-absent UP-call): the mirror of the gene-absent gate for gains. An UP call
   # (higher in perturbation) whose CONTROL arm carries ~zero UMIs is an "increase" over a baseline
   # we never detected -- uncallable, and the control-split null cannot price it (control-vs-control
   # is 0 in both arms). A DOWN call with an empty perturbation arm is the opposite case (a real
   # depletion) and is NOT gated. Directional on the control (reference) arm.
   up_absent_gate <- (out$z > 0) & is.finite(out$K_ctrl) & (out$K_ctrl < .EFDR_MIN_ARM_UMI)
-  out$empirical_p[up_absent_gate] <- 1
+  if (on("gain_from_zero")) out$empirical_p[up_absent_gate] <- 1
   # Gate 3c (empty-gaining-arm UP-call): an UP call (higher in perturbation) whose PERTURBATION
   # (gaining) arm carries ~zero UMIs cannot be a real gain -- the gene is absent from the very arm
   # it is called up in, so the shrunken-LFC sign is noise (a near-zero control arm plus size-factor
@@ -633,7 +752,7 @@ annotate_empirical_fdr_model <- function(model, deg_tbl, log_ratio = NULL, detec
   # floor used for losses: real GAINS can be sparse (phox2a is real at 0.7% perturbation detection,
   # K_pert>0), so only a truly empty gaining arm is gated. Directional on the perturbation arm.
   up_empty_gain_gate <- (out$z > 0) & is.finite(out$K_pert) & (out$K_pert < .EFDR_MIN_ARM_UMI)
-  out$empirical_p[up_empty_gain_gate] <- 1
+  if (on("gain_no_counts")) out$empirical_p[up_empty_gain_gate] <- 1
   # Gate 3b (low source-detection LOSS): a DOWN call whose CONTROL (source) arm detects the gene in
   # fewer than MIN_SRC_DET of its cells has no robustly-expressed baseline to lose -- its large |z|
   # is trend-dispersion shrinkage noise the control-split null cannot reach at moderate arm sizes
@@ -643,29 +762,37 @@ annotate_empirical_fdr_model <- function(model, deg_tbl, log_ratio = NULL, detec
   # low-expression artifacts (<=1.1%). NA detection -> not gated (no data to judge).
   out$det_ctrl <- out$n_expr_ctrl / out$n_ctrl_cells
   low_src_det_gate <- (out$z < 0) & is.finite(out$det_ctrl) & (out$det_ctrl < .EFDR_MIN_SRC_DET)
-  out$empirical_p[low_src_det_gate] <- 1
-  # Gate 4 (minimum cells in the thinner arm, BOTH directions): a contrast whose thinner arm holds
-  # fewer than MIN_ARM_CELLS cells is uncallable regardless of expression or direction. A complete
-  # absence of the gene in the thin arm is a real depletion ONLY if that arm had enough cells to have
-  # detected the gene -- e.g. brd1b in a cell type depleted to 8 perturbation cells (none expressing)
-  # is a too-few-cells call, not a loss. Gated on the CELL COUNT of the thinner arm only, NOT on
-  # detection or the control:perturbation ratio (which is unreliable for rare cell types), so it is
-  # robust for rare cell types and does not try to price sub-floor arms in the null (which cannot
-  # simulate a thin arm against a very deep control arm anyway). Being symmetric, it also subsumes the
-  # old up-only thin-gain gate: the control-split null structurally cannot generate a thin-arm GAIN,
-  # and the same cell floor covers that. The floor value is LOCATED per experiment by the Poisson
-  # power argument above (constants .EFDR_MIN_EXPECTED / .EFDR_DET_PCTL): a well-detected gene (p =
-  # .EFDR_DET_PCTL-th percentile of positive control detection) needs 3/p thin-arm cells before a
-  # complete absence is distinguishable from undersampling. Falls back to .EFDR_MIN_ARM_CELLS if the
-  # detection distribution is degenerate.
-  .p_det <- suppressWarnings(stats::quantile(
-    out$det_ctrl[is.finite(out$det_ctrl) & out$det_ctrl > 0], .EFDR_DET_PCTL, names = FALSE))
-  min_arm_cells <- if (is.finite(.p_det) && .p_det > 0)
-    as.integer(ceiling(.EFDR_MIN_EXPECTED / .p_det)) else .EFDR_MIN_ARM_CELLS
-  message(sprintf("[efdr] min-arm-cell floor located at K=%d (p%.0f control detection = %.3f)",
-                  min_arm_cells, 100 * .EFDR_DET_PCTL, .p_det))
-  min_arm_gate <- is.finite(out$thin_arm_cells) & (out$thin_arm_cells < min_arm_cells)
-  out$empirical_p[min_arm_gate] <- 1
+  if (on("loss_from_trace")) out$empirical_p[low_src_det_gate] <- 1
+  # too_few_cells (BOTH directions): was the thinner arm powered to see THIS gene? Expected
+  # detections = (cells in the thinner arm) x (the better-estimated of the two arms' detection
+  # rates); below .EFDR_MIN_EXPECTED, "we saw none / fewer" cannot be told from "we did not sample
+  # it" (derivation at the constant). A complete absence in the thin arm is a real depletion only
+  # if that arm could have detected the gene -- brd1b in a cell type depleted to 8 perturbation
+  # cells, none expressing, is a too-few-cells call, not a loss. Being per call, it keeps a
+  # well-detected gene callable in a small cell type and gates a trace gene even in a large one;
+  # the flat floor it replaces could do neither. Symmetric on purpose: it also covers thin-arm
+  # GAINS, which the control-split null structurally cannot generate. NA counts -> not gated.
+  out$det_pert  <- out$n_expr_pert / out$n_pert_cells
+  out$max_det   <- pmax(out$det_ctrl, out$det_pert, na.rm = TRUE)
+  out$expected_detections <- out$thin_arm_cells * out$max_det
+  underpowered_gate <- is.finite(out$expected_detections) &
+    out$expected_detections < .EFDR_MIN_EXPECTED
+  if (on("too_few_cells")) out$empirical_p[underpowered_gate] <- 1
+
+  # flat_cell_floor: the RETIRED per-experiment cell floor, off by default. Kept so the previous
+  # policy is reproducible via `gates` for back-comparison. K is located from the p75 of control
+  # detection, which is why it varied 24-58 across experiments and tracked cell-type size
+  # composition as much as capture depth.
+  min_arm_cells <- NA_integer_; .p_det <- NA_real_
+  if (on("flat_cell_floor")) {
+    .p_det <- suppressWarnings(stats::quantile(
+      out$det_ctrl[is.finite(out$det_ctrl) & out$det_ctrl > 0], .EFDR_DET_PCTL, names = FALSE))
+    min_arm_cells <- if (is.finite(.p_det) && .p_det > 0)
+      as.integer(ceiling(.EFDR_MIN_EXPECTED / .p_det)) else .EFDR_MIN_ARM_CELLS
+    message(sprintf("[efdr] legacy flat cell floor K=%d (p%.0f control detection = %.3f)",
+                    min_arm_cells, 100 * .EFDR_DET_PCTL, .p_det))
+    out$empirical_p[is.finite(out$thin_arm_cells) & out$thin_arm_cells < min_arm_cells] <- 1
+  }
 
   # empirical_fdr: BH-adjust EACH floor within the cell group, then take the max q -- NOT
   # BH(empirical_p) (the per-gene max compresses the p-distribution so BH crushes real hits).
@@ -685,9 +812,11 @@ annotate_empirical_fdr_model <- function(model, deg_tbl, log_ratio = NULL, detec
   # decorator stage -- can persist them; the located min-arm K in particular is otherwise only in
   # the log). Counts are gate MEMBERSHIP (a call may satisfy more than one gate, so they need not sum).
   attr(out, "efdr_stats") <- data.frame(
-    min_arm_cells_K       = as.integer(min_arm_cells),
+    min_arm_cells_K       = as.integer(min_arm_cells),   # NA unless flat_cell_floor is on
     p_ctrl_detection      = round(as.numeric(.p_det), 4),
     det_pctl              = .EFDR_DET_PCTL,
+    gates_applied         = paste(gates, collapse = ","),
+    min_replicate_embryos = as.integer(min_replicate_embryos),
     n_calls               = nrow(out),
     n_ashr_sig            = sum(out$p_ashr < 0.05, na.rm = TRUE),
     n_retained            = sum(out$empirical_p < 0.05, na.rm = TRUE),
@@ -698,7 +827,8 @@ annotate_empirical_fdr_model <- function(model, deg_tbl, log_ratio = NULL, detec
     n_gate_up_ctrl_absent = sum(up_absent_gate, na.rm = TRUE),
     n_gate_up_empty_gain  = sum(up_empty_gain_gate, na.rm = TRUE),
     n_gate_low_ctrl_det   = sum(low_src_det_gate, na.rm = TRUE),
-    n_gate_min_arm_cells  = sum(min_arm_gate, na.rm = TRUE),
+    n_gate_too_few_cells  = sum(underpowered_gate, na.rm = TRUE),
+    n_gate_not_replicated = sum(not_replicated_gate, na.rm = TRUE),
     stringsAsFactors = FALSE)
   out
 }

--- a/tests/testthat/test-efdr-gates.R
+++ b/tests/testthat/test-efdr-gates.R
@@ -1,0 +1,125 @@
+# The uncallability gate policy of annotate_empirical_fdr_model(). The tail null is stubbed out
+# (a surface whose quantiles sit far below any observed |z|, so p_tail is ~0 and drops out of
+# max(p_ashr, p_tail)) -- these tests are about which calls the GATES pin to 1, nothing else.
+stub_model <- function() {
+  taus  <- c(0.5, 0.9, 0.999)
+  egrid <- c(-6, -3, 0); pegrid <- c(0, 1, 2, 3)
+  Q <- matrix(-1e6, nrow = length(egrid) * length(pegrid), ncol = length(taus))
+  list(surf = list(dn = Q, up = Q), taus = taus, egrid = egrid, pegrid = pegrid)
+}
+
+# One row per scenario. Each is strongly significant by ashr, so anything that ends at
+# empirical_p == 1 was gated and anything below 0.05 was not.
+gate_fixture <- function() {
+  deg <- data.frame(
+    id                   = c("well_det_small_arm", "trace_big_arm", "gain_from_zero",
+                             "one_embryo", "absent_both", "complete_depletion"),
+    gene_short_name      = c("well_det_small_arm", "trace_big_arm", "gain_from_zero",
+                             "one_embryo", "absent_both", "complete_depletion"),
+    cell_group           = "CT",
+    log_mean_expression  = -3,
+    perturb_to_ctrl_shrunken_lfc = c(-2, -2, 2, 2, -2, -2),
+    perturb_to_ctrl_p_value      = 1e-8,
+    z                    = c(-6, -6, 6, 6, -6, -6),
+    stringsAsFactors     = FALSE)
+  # arm_cells is per cell type, so every row shares one arm geometry: a 900-cell control arm
+  # against a 9-cell perturbation arm. thin_arm_cells = 9 throughout.
+  arm_cells <- data.frame(cell_group = "CT", n_ctrl_cells = 900, n_pert_cells = 9)
+  counts <- data.frame(
+    id = deg$id, gene_short_name = deg$id, cell_group = "CT",
+    K_ctrl      = c(2000,  15,   0,    5, 0, 2000),
+    K_pert      = c(  20,   0,  40,   40, 0,    0),
+    # 38% control detection -> 9 * 0.38 = 3.42 expected in the thin arm: powered.
+    # trace_big_arm is 1% -> 0.09 expected, despite its 900-cell control arm.
+    # gain_from_zero has nothing in control and 3 of 9 perturbation cells -> 9 * 1/3 = 3.
+    # one_embryo is powered the same way (3 of 9) but every detection sits in one embryo.
+    n_expr_ctrl = c( 342,   9,   0,    1, 0,  342),
+    n_expr_pert = c(   3,   0,   3,    3, 0,    0),
+    n_emb_ctrl  = c(  20,   7,   0,    1, 0,   20),
+    n_emb_pert  = c(   3,   0,   3,    1, 0,    0),
+    stringsAsFactors = FALSE)
+  support <- data.frame(cell_group = "CT", n_pert_pb = 9)
+  list(deg = deg, arm_cells = arm_cells, counts = counts, support = support)
+}
+
+ep <- function(out, id) out$empirical_p[match(id, out$id)]
+
+test_that("the default policy gates on power per call, not on arm size", {
+  f <- gate_fixture()
+  out <- annotate_empirical_fdr_model(stub_model(), f$deg, arm_cells = f$arm_cells,
+                                      counts = f$counts, support = f$support)
+
+  # A well-detected gene stays callable in a 9-cell arm: 9 cells x 38% = 3.42 expected >= 3.
+  expect_lt(ep(out, "well_det_small_arm"), 0.05)
+  # A trace gene is gated even though its control arm is large: 9 x 2% = 0.18 expected.
+  expect_equal(ep(out, "trace_big_arm"), 1)
+  # A gain from a zero baseline is testable, because the rate comes from the arm that has the
+  # gene: 9 cells x (3/9) = 3 expected. The retired gain_from_zero rule killed this outright.
+  expect_lt(ep(out, "gain_from_zero"), 0.05)
+  # Powered, but every detection sits in a single embryo in either arm -> not_replicated.
+  expect_equal(ep(out, "one_embryo"), 1)
+  # No counts in either arm: caught by not_replicated (0 embryos), so not_detected_anywhere
+  # is not needed to reach it.
+  expect_equal(ep(out, "absent_both"), 1)
+  # A complete depletion out of a well-replicated control arm survives: the thin arm was
+  # powered (3.42 expected) and the gene is replicated in 20 control embryos.
+  expect_lt(ep(out, "complete_depletion"), 0.05)
+
+  st <- attr(out, "efdr_stats")
+  expect_equal(st$gates_applied, "too_few_embryos,not_replicated,too_few_cells")
+  expect_true(is.na(st$min_arm_cells_K))     # K is not located unless flat_cell_floor is on
+  expect_equal(st$min_replicate_embryos, 2L)
+  expect_equal(st$n_gate_not_replicated, 2L) # one_embryo and absent_both
+  expect_equal(st$n_gate_too_few_cells,  2L) # trace_big_arm and absent_both
+})
+
+test_that("the previous policy is reproducible via `gates`", {
+  f <- gate_fixture()
+  legacy <- c("too_few_embryos", "not_detected_anywhere", "gain_from_zero",
+              "gain_no_counts", "loss_from_trace", "flat_cell_floor")
+  out <- annotate_empirical_fdr_model(stub_model(), f$deg, arm_cells = f$arm_cells,
+                                      counts = f$counts, support = f$support, gates = legacy)
+  # The two policies differ in BOTH directions, which is the point of keeping this path.
+  # gain_from_zero killed real ectopic activation on an absolute zero-UMI rule -- this is the
+  # shape of the osr1 sox9a call.
+  expect_equal(ep(out, "gain_from_zero"), 1)
+  # loss_from_trace reached the trace gene too, by a different route (1% control detection).
+  expect_equal(ep(out, "trace_big_arm"), 1)
+  # ...but the previous policy had no replication requirement, so a call whose every detection
+  # sits in one embryo passed.
+  expect_lt(ep(out, "one_embryo"), 0.05)
+
+  st <- attr(out, "efdr_stats")
+  expect_equal(st$gates_applied, paste(legacy, collapse = ","))
+  # K is a single number for the entire table, located from the p75 of control detection --
+  # here 38%, so ceil(3/0.38) = 8. It happens to land just under this cell type's 9-cell arm
+  # and so fires on nothing; had detection been slightly lower it would have taken out every
+  # gene in the cell type, well-expressed ones included. That sensitivity to a distributional
+  # summary, rather than to the call being judged, is what the per-call test removes.
+  expect_equal(st$min_arm_cells_K, 8L)
+  expect_equal(st$p_ctrl_detection, 0.38)
+})
+
+test_that("gates are computed even when not applied, and unknown names error", {
+  f <- gate_fixture()
+  out <- annotate_empirical_fdr_model(stub_model(), f$deg, arm_cells = f$arm_cells,
+                                      counts = f$counts, support = f$support,
+                                      gates = character())
+  # Nothing applied -> empirical_p is max(p_ashr, p_tail) for every row...
+  expect_true(all(out$empirical_p < 0.05))
+  # ...but membership is still counted, which is what makes the diagnostics comparable
+  # across policies.
+  expect_gt(attr(out, "efdr_stats")$n_gate_not_replicated, 0)
+
+  expect_error(annotate_empirical_fdr_model(stub_model(), f$deg, arm_cells = f$arm_cells,
+                                            counts = f$counts, support = f$support,
+                                            gates = c("too_few_cells", "no_such_gate")),
+               "unknown gate")
+})
+
+test_that("missing counts disable the count-driven gates rather than gating everything", {
+  f <- gate_fixture()
+  out <- annotate_empirical_fdr_model(stub_model(), f$deg, arm_cells = f$arm_cells,
+                                      support = f$support)
+  expect_true(all(out$empirical_p < 0.05))
+})


### PR DESCRIPTION
# platt — one gate policy for every experiment

**Branch:** `efdr-replicability-gate` → `main`
**File:** `R/empirical_fdr_model.R`

## What this changes

The empirical-FDR decoration applied six uncallability gates, each of which pins `empirical_p` to 1.
Three of them were absolute rules about zero counts and one was a per-experiment cell floor `K`.
This PR replaces that set with three gates, and makes the set selectable so the previous policy can
be reproduced side by side.

**The policy is now:**

| gate | condition |
|---|---|
| `too_few_embryos` | fewer than 2 perturbation embryos in the cell type — no two-group contrast exists |
| `not_replicated` | the gene was detected in fewer than 2 distinct embryos in **both** arms |
| `too_few_cells` | `min(n_ctrl_cells, n_pert_cells) × max(det_ctrl, det_pert) < 3` |

`too_few_cells` keeps its name but its meaning changed, so existing configs and diagnostics keep
working. Everything else stays: `empirical_p = max(p_ashr, p_tail)` is untouched, and every gate is
still demote-only.

**Off by default, each still selectable via `gates`:** `not_detected_anywhere`, `gain_from_zero`,
`gain_no_counts`, `loss_from_trace`, and `flat_cell_floor` (the retired `K`).

## Why

### The cell floor asked the wrong question

`K = ceil(3 / p75(det_ctrl))` came from a Poisson argument — a gene detected in a fraction `p` of
cells is expected in `n·p` of `n` cells, and at `n·p = 3` the chance of seeing none is `exp(-3) ≈ 5%`,
so below that "we saw none" is not distinguishable from "we did not sample it." That argument is
sound. Applying it once per experiment, to a single reference gene at the 75th percentile of control
detection, is what went wrong: the floor then asks only *how many cells are in this arm*, so it
discards every gene in a small cell type regardless of how well expressed it is, and waves through
trace genes in large ones.

It also came out backwards across experiments — `K = 35` for SGSeq2 and `27` for GENE6, which is far
deeper. `K` tracks the cell-type size composition of a run as much as its capture depth.

Two calls from GENE6 make the failure concrete:

- **`jcada` in gill ionocyte** — retained under `K`. 18 of 807 control cells across 14 embryos
  (2.2% detection), 100 mutant cells. Expected detections in the thin arm: **2.23**. The mutant arm
  was never powered to see this gene.
- **`bsnb` in starburst amacrine cell** — gated by `K`. 639 of 1,665 control cells across 56 embryos
  (38% detection), 9 mutant cells with 3 detecting. Expected detections: **3.45**. A gene present in
  more than a third of cells, in an arm small enough that 3 of 9 is what you would predict.

The flat floor got both backwards. Testing the same Poisson expectation **per call** gets both right,
and drops the two constants that had no derivation (the .75 percentile, and the idea of one reference
gene standing in for all of them). `.EFDR_MIN_EXPECTED = 3` is the only constant left in this gate.

Reading `p` as `max(det_ctrl, det_pert)` is what keeps a gain from a zero baseline testable: the
arm that carries the gene supplies the rate, and the thin arm supplies only its cell count, which is
exact.

### The zero-count rules were the wrong instrument

`gain_from_zero` gated any up-call whose control arm had zero UMI. It cannot tell one stray cell from
sixteen, so on lower-depth runs it removed real ectopic activation. It is what killed **sox9a** (0 of
38 control cells → 4 of 47 mutant across 4 embryos) and **col11a2** in `fibroblast, meninx
(slc47a2.1+)` in the osr1 contrast — a balanced design with no thin arm at all. The expected-detections
test answers the question those rules were reaching for directly, and prices it.

`not_detected_anywhere` is subsumed by `not_replicated`: a gene seen in ≥2 embryos of either arm
necessarily has counts somewhere. `gain_no_counts` was measured to remove **zero** otherwise-surviving
calls across all six test experiments once `too_few_cells` applies everywhere — it fires on up to 10%
of calls but never on one that would have survived. `loss_from_trace` was a flat 2% control-detection
floor that removed calls replicated across 20+ embryos purely for being lowly expressed; 64–82% of
what it uniquely removed is caught by expected detections, on a derived quantity rather than a
declared one.

### What `not_replicated` adds

At ~500 UMI/cell most genes are absent from any given cell, so seeing the same gene in two separate
embryos of one arm and none of the other is not something the sampling produces easily — which is
exactly what the arm-matched null prices. That makes replication across specimens a better instrument
than an absolute zero-UMI threshold. It is deliberately direction- and arm-agnostic: it asks whether
the gene is really measured in this cell type at all, not which way it moved.

## Effect on call counts

Retained calls at `empirical_p < 0.05`, one perturbation per experiment (a representative one, not the
whole experiment):

| experiment | perturbation | as shipped | three gates | gained | lost |
|---|---|---|---|---|---|
| ATOH7 | atoh7 | 2,089 | 5,413 | 3,802 | 478 |
| GAP16 | cdx4 | 14,665 | 20,407 | 6,146 | 404 |
| GENE6 | myod1,six1a,six1b | 98,134 | 99,885 | 11,099 | 9,348 |
| GENE8 | gata5 | 104,374 | 120,972 | 21,163 | 4,565 |
| LMX1Blate | lmx1ba,lmx1bb | 6,035 | 14,459 | 8,873 | 449 |
| SGSeq2 | osr1 | 12,048 | 20,350 | 10,699 | 2,397 |

Whole experiments, re-decorated end to end through the pipeline:

| experiment | perturbations | previous policy | three gates | gained | lost |
|---|---|---|---|---|---|
| SGSeq2 | 5 | 39,012 | 83,029 | 54,170 | 10,153 |
| GENE6 | 15 | 976,325 | 1,027,115 | 138,729 | 87,939 |

GENE6 is close to a wash overall, and two of its 15 perturbations come out net negative (`myod1`
95,831 → 94,891; `pbx1b,pbx4` 76,278 → 73,150). That is the policy trading breadth for support, not
a regression.

The composition matters more than the totals. **In every one of the 20 perturbations re-decorated
through the pipeline, 0% of the gained calls rest on ≤2 cells** — against 11–43% for a variant that
keeps `K`. This is not luck; it follows from the rule (expected ≥ 3 forces the carrying arm to hold at
least 3 detecting cells).

Gained calls in GENE6 have a median of 7–59 detecting cells across 6–32 embryos, and 16–67% of them
are above 10% detection — well-measured genes, not thin-arm noise. Lost calls have a median expected
**1.56–2.00** detections. In SGSeq2 the same split is a median 4 cells / 4 embryos gained against a
median expected 2.0–2.2 lost.

GENE6's `myod1,six1a,six1b` is the one contrast that loses a lot (9,348 shipped calls). 79% of those
are depletions where the control arm is well replicated but the mutant arm has a median expected 1.71
detections and a median `P(0 | no change)` of 18% — 76% of them are above 10%. Kept down-calls in the
same contrast have median expected 30.4 and `P(0) = 0.0%`. These are not muscle: they are complete
absences in arms that were never powered to see the gene.

## Validation

**Amy's labelled GENE6 calls** (myod1/six1a/six1b, the only perturbations she scored — all 20 matched
against pipeline output): **0 newly admitted, 0 newly dropped.** 10 of 10 confirmed artifacts stay
demoted, 8 of 9 trusted calls stay kept, the 1 borderline stays out. The policy change does not touch
her ground truth in either direction.

**The previous gate set reproduces production exactly.** Running this branch with
`gates = c("too_few_embryos", "not_detected_anywhere", "gain_from_zero", "gain_no_counts",
"loss_from_trace", "flat_cell_floor")` over all five SGSeq2 perturbations: **5,550,420 rows,
`empirical_p` identical to the last bit in 100.0000% of them, 0 call-set disagreements.** That is what
makes every difference above attributable to the policy rather than to an incidental code change.
Repeated over all 15 GENE6 perturbations — **44,982,636 rows, 0 call-set disagreements.**

The `drop0` fix below turns out to be silent on both, and on four of the six published experiments
checked: only GENE8's `contrast_cds` carries explicit stored zeros. So it changes nothing in the
comparisons above, and the numbers are the policy alone.

**Stephen's osr1 chondrogenic/ECM panel.** Of the 122 ashr-significant rows in that gene set, 11 were
retained as shipped and 19 are retained now (11 recovered, 3 lost). The recoveries are large,
well-replicated effects the zero-count rules had removed: `col9a2` in mesodermal smooth muscle
(lfc −3.85, 4 of 275 control cells across 4 embryos → 0 of 274), `col11a2` in eye photoreceptor
(lfc 3.07, 0 → 5 of 699 across 5 embryos), `sox9a` in `fibroblast, meninx (slc47a2.1+)` (lfc 3.03,
0 of 38 → 4 of 47 across 4 embryos). All 3 losses are complete depletions at expected 1.55–2.59
detections.

`col11a2` in `fibroblast, meninx (slc47a2.1+)` does **not** come back: 3 of 47 mutant cells against a
38-cell control arm is expected 2.43, just under the bar. `col2a1a`, `col2a1b` and `col9a2` in that
cell type were never ashr-significant in the v3.1.0 fit (p = 0.22, 0.33, 0.072), so no gate change
reaches them — `empirical_p = max(p_ashr, p_tail)` only ever demotes.

## Two bugs fixed along the way

**Explicit stored zeros were counted as expressing cells.** `.efdr_arm_counts` binarises the
expression matrix with `Db@x[] <- 1`. A materialised BPCells matrix can carry explicit zeros in its
sparsity pattern — 4.65% of stored entries in GENE8's `contrast_cds` — so every one of them was counted
as a cell expressing the gene. That inflates `n_expr_*` and therefore `det_ctrl`, which drove the
low-source-detection gate. The symptom in a shipped table is the arithmetically impossible
`K_ctrl < n_expr_ctrl`. Across the six published experiments checked:

| experiment | rows | impossible rows |
|---|---|---|
| GENE8 gata5 | 4,553,642 | **891,089 (19.57%)** |
| GENE6 myod1 | 2,996,873 | 0 |
| SGSeq2 osr1 | 1,111,886 | 0 |
| ATOH7 atoh7 | 471,547 | 0 |
| LMX1Blate lmx1ba,lmx1bb | 1,235,993 | 0 |
| GAP16 cdx4 | 1,099,106 | 0 |

So it is narrow — GENE8 only, of these — but real there, and worth fixing before anything else is
built on `det_ctrl`. Fixed with `Matrix::drop0`. Pre-existing production bug, independent of the gate
policy.

**Duplicate gene IDs were counted as embryos.** The symbol-keyed fallback in `.efdr_join_counts` sums
across a symbol's IDs, which is right for UMI and cell counts but not for embryo counts — one embryo
detecting two IDs of a symbol would be counted twice. Multi-copy loci made this stark (5S_rRNA has
~1,947 IDs). Embryo counts now take `max()`, and the primary path keys strictly on gene `id`.

## New columns in the decorated table

`n_emb_ctrl`, `n_emb_pert` (distinct embryos detecting the gene per arm), `det_pert`, `max_det`,
`expected_detections`. `efdr_stats` gains `gates_applied`, `min_replicate_embryos`,
`n_gate_not_replicated`, `n_gate_too_few_cells`; `min_arm_cells_K` is now `NA` unless
`flat_cell_floor` is on.

## Follow-up

All published runs need re-decorating. No DEG re-fit is needed — this is the decoration stage only,
and the null is a property of the experiment's control cells, not of the gate policy, so
`--model_in` can reuse the existing `efdr_model.rds`.
