### PR TITLE
Fix fgsea determinism and deprecated permutation path

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,8 @@ Imports:
     mgcv,
     scam,
     speedglm,
-    splines
+    splines,
+    withr
 Remotes:
     cole-trapnell-lab/speedglm,
     bioc::fgsea

--- a/R/deg.R
+++ b/R/deg.R
@@ -2257,6 +2257,10 @@ update_summary <- function(model_tbl, dispersion_type = c("max", "fitted", "esti
 #' @param gene_patterns_within_state_graph A data frame containing gene pattern activity scores.
 #' @param gene_df A data frame containing gene information with columns `gene_short_name` and `gs_name`.
 #' @param sig_thresh A numeric value specifying the significance threshold for adjusted p-values. Default is 0.1.
+#' @param seed_key An optional character string identifying this call, used to derive a
+#'   deterministic RNG seed (fgseaMultilevel is Monte Carlo). Defaults to NULL, in which case
+#'   the seed is derived from `gene_ranking`/`gene_set_list` themselves, so results are still
+#'   reproducible per-input without requiring the caller to supply anything.
 #'
 #' @return A tibble containing the GSEA results filtered by the specified significance threshold.
 #'
@@ -2275,11 +2279,18 @@ update_summary <- function(model_tbl, dispersion_type = c("max", "fitted", "esti
 #' @export
 calc_gsea_enrichment_on_state_specific_genes <- function(gene_patterns_within_state_graph,
                                                          gene_df,
-                                                         sig_thresh = 0.1) {
+                                                         sig_thresh = 0.1,
+                                                         seed_key = NULL) {
   gene_set_list <- split(x = gene_df$gene_short_name, f = gene_df$gs_name)
   gene_ranking <- gene_patterns_within_state_graph$pattern_activity_score[, 1]
   names(gene_ranking) <- gene_patterns_within_state_graph %>% pull(gene_short_name)
-  gsea_res <- fgsea::fgsea(pathways = gene_set_list, stats = gene_ranking) %>% as_tibble()
+  if (is.null(seed_key)) {
+    seed_key <- paste(c(names(gene_ranking), names(gene_set_list)), collapse = "|")
+  }
+  seed <- .fgsea_seed_from_key(seed_key)
+  gsea_res <- withr::with_seed(seed, {
+    fgsea::fgsea(pathways = gene_set_list, stats = gene_ranking)
+  }) %>% as_tibble()
   gsea_res <- gsea_res %>% filter(padj < sig_thresh)
   return(gsea_res)
 }

--- a/R/phenotype_assignment_utils.R
+++ b/R/phenotype_assignment_utils.R
@@ -42,30 +42,64 @@ make_rank <- function(deg_tbl,
     sort(r, decreasing = TRUE)
 }
 
-# Run fgsea on the preranked vector for a list of gene sets
+# Deterministic 31-bit hash of a string, used to derive a reproducible RNG seed
+# from a call's own identity rather than from loop position. Double arithmetic
+# (not integer) avoids 32-bit overflow; strength/collision-resistance doesn't
+# matter here, only that identical keys always map to the same seed.
+.fgsea_seed_from_key <- function(key) {
+    h <- 5381
+    for (b in utf8ToInt(enc2utf8(key))) h <- (h * 33 + b) %% 2147483647
+    as.integer(h)
+}
+
+# Run fgsea on the preranked vector for a list of gene sets.
+#
+# Always dispatches to fgseaMultilevel (no `nperm` is ever forwarded to
+# fgsea::fgsea() -- passing nperm there forces the deprecated fgseaSimple path,
+# which floors padj resolution at ~1/(nperm+1) and emits a warning this
+# function used to swallow via suppressWarnings). `nperm` is kept as the
+# parameter name for backward compatibility with existing callers, but its
+# value now maps onto fgseaMultilevel's `nPermSimple` (preliminary estimation
+# permutations).
+#
+# Seeding: fgseaMultilevel is Monte Carlo, so identical inputs must get an
+# identical seed to be reproducible. The seed is derived from `seed_key` --
+# ideally the calling context's own identity (e.g. "<perturb_name>::<cell_group>::fitness"),
+# passed in by the caller -- so results depend only on that call's own inputs,
+# not on loop order, worker count, or serial vs. parallel execution. If no
+# seed_key is supplied, one is derived from the gene ranking and gene sets
+# themselves, which is still deterministic per-call but ties reproducibility
+# to the data rather than to caller-supplied metadata.
 run_fgsea_modules <- function(rank_vec,
                               gene_sets,
                               minSize = 10,
                               maxSize = 5000,
-                              nperm = 10000) {
+                              nperm = 1000,
+                              seed_key = NULL) {
     # Keep only present genes per set
     gs <- lapply(gene_sets, function(v) intersect(unique(v), names(rank_vec)))
     keep <- lengths(gs) >= minSize
     if (!any(keep)) {
-        return(tibble(path = character(), NES = numeric(), padj = numeric(), size = integer(), leading_edge = character()))
+        return(tibble(path = character(), NES = numeric(), padj = numeric(), size = integer(), log2err = numeric(), leading_edge = character()))
     }
     gs <- gs[keep]
-    suppressWarnings({
-        res <- fgsea::fgsea(
-            pathways = gs, stats = rank_vec,
-            minSize = minSize, maxSize = maxSize, nperm = nperm
-        )
+    if (is.null(seed_key)) {
+        seed_key <- paste(c(names(rank_vec), names(gs)), collapse = "|")
+    }
+    seed <- .fgsea_seed_from_key(seed_key)
+    res <- withr::with_seed(seed, {
+        suppressWarnings({
+            fgsea::fgsea(
+                pathways = gs, stats = rank_vec,
+                minSize = minSize, maxSize = maxSize, nPermSimple = nperm
+            )
+        })
     })
     res %>%
         as_tibble() %>%
-        select(pathway, size, NES, padj, leadingEdge) %>%
+        select(pathway, size, NES, padj, log2err, leadingEdge) %>%
         mutate(leading_edge = vapply(leadingEdge, function(x) paste(x, collapse = ";"), character(1))) %>%
-        select(pathway, size, NES, padj, leading_edge) %>%
+        select(pathway, size, NES, padj, log2err, leading_edge) %>%
         arrange(padj, desc(abs(NES))) %>%
         rename(path = pathway)
 }
@@ -181,7 +215,7 @@ score_fitness_from_deg <- function(deg_tbl,
                                    logFC_col = "logFC",
                                    padj_col = "padj",
                                    minSize = 10,
-                                   nperm = 10000,
+                                   nperm = 1000,
                                    nes_mod = 1.5,
                                    nes_sev = 2.0,
                                    q_cut = 0.05) {
@@ -265,7 +299,7 @@ assign_phenotypes <- function(
   use_summarized_tbl = TRUE,
   minSize = 10,
   maxSize = 5000,
-  nperm = 10000
+  nperm = 1000
 ) {
     # Get all cell types across all perturbations
     all_cell_types <- unique(unlist(
@@ -376,7 +410,7 @@ assign_phenotypes_to_cell_types <- function(
   num_threads = NULL,
   minSize = 10,
   maxSize = 5000,
-  nperm = 10000
+  nperm = 1000
 ) {
     cell_types <- unique(dact_tbl$cell_group)
     num_threads <- get_phenotype_threads(num_threads)
@@ -396,8 +430,8 @@ assign_phenotypes_to_cell_types <- function(
         dact_row <- dact_tbl %>% filter(cell_group == ct)
         abundance_code <- if (nrow(dact_row) > 0) assign_abundance_code(dact_row$change_when_present, dact_row$change_when_present_q_val) else NA_character_
         abundance_severity <- if (nrow(dact_row) > 0) assign_abundance_severity(dact_row$change_when_present, dact_row$change_when_present_q_val) else NA_character_
-        identity_assignment <- assign_identity_maturation_labels(deg_tbl, ct, identity_gene_sets, combined_psg, minSize = minSize, nperm = nperm, maxSize = maxSize)
-        fitness_assignment <- assign_fitness_labels(deg_tbl, ct, gene_sets, minSize = minSize, nperm = nperm, maxSize = maxSize)
+        identity_assignment <- assign_identity_maturation_labels(deg_tbl, ct, identity_gene_sets, combined_psg, minSize = minSize, nperm = nperm, maxSize = maxSize, perturb_name = perturb_name)
+        fitness_assignment <- assign_fitness_labels(deg_tbl, ct, gene_sets, minSize = minSize, nperm = nperm, maxSize = maxSize, perturb_name = perturb_name)
         if (!is.null(log_fn)) {
             elapsed <- as.numeric(difftime(Sys.time(), ct_start, units = "secs"))
             log_fn(sprintf(
@@ -462,11 +496,13 @@ assign_abundance_severity <- function(change_when_present, change_when_present_q
 assign_fitness_labels <- function(deg_tbl, ct, gene_sets,
                                   minSize = 10,
                                   maxSize = 5000,
-                                  nperm = 10000) {
+                                  nperm = 1000,
+                                  perturb_name = NULL) {
     degs_this_cell <- deg_tbl %>% filter(cell_group == ct)
     if (nrow(degs_this_cell) > 0) {
         rank_vec <- make_rank(degs_this_cell, gene_col = "gene_short_name", logFC_col = "perturb_to_ctrl_shrunken_lfc")
-        fgsea_res <- run_fgsea_modules(rank_vec, gene_sets, minSize = minSize, maxSize = maxSize, nperm = nperm)
+        seed_key <- paste(perturb_name, ct, "fitness", sep = "::")
+        fgsea_res <- run_fgsea_modules(rank_vec, gene_sets, minSize = minSize, maxSize = maxSize, nperm = nperm, seed_key = seed_key)
         list(
             labels = classify_fitness(fgsea_res),
             fgsea_res = fgsea_res
@@ -483,7 +519,8 @@ assign_identity_maturation_labels <- function(deg_tbl, ct, identity_gene_sets, c
                                               nes_mod = 1.5, nes_sev = 2.0, q_cut = 0.05,
                                               minSize = 10,
                                               maxSize = 5000,
-                                              nperm = 10000) {
+                                              nperm = 1000,
+                                              perturb_name = NULL) {
     degs_this_cell <- deg_tbl %>% filter(cell_group == ct)
     if (nrow(degs_this_cell) == 0) {
         return(list(
@@ -525,7 +562,8 @@ assign_identity_maturation_labels <- function(deg_tbl, ct, identity_gene_sets, c
 
     # Prepare for fgsea
     rank_vec <- make_rank(degs_this_cell, gene_col = "gene_short_name", logFC_col = "perturb_to_ctrl_shrunken_lfc")
-    fgsea_res <- run_fgsea_modules(rank_vec, gene_sets_list, minSize = minSize, maxSize = maxSize, nperm = nperm)
+    seed_key <- paste(perturb_name, ct, "identity", sep = "::")
+    fgsea_res <- run_fgsea_modules(rank_vec, gene_sets_list, minSize = minSize, maxSize = maxSize, nperm = nperm, seed_key = seed_key)
 
     # Annotate each result with its cell type and gene set
     fgsea_res <- fgsea_res %>%

--- a/tests/testthat/test-gsea-enrichment.R
+++ b/tests/testthat/test-gsea-enrichment.R
@@ -1,0 +1,54 @@
+test_helper_make_state_gsea_fixture <- function(seed = 1) {
+    set.seed(seed)
+    genes <- paste0("gene", seq_len(300))
+    gene_patterns_within_state_graph <- data.frame(gene_short_name = genes)
+    gene_patterns_within_state_graph$pattern_activity_score <- matrix(rnorm(length(genes)), ncol = 1)
+    gene_df <- data.frame(
+        gene_short_name = c(genes[1:20], genes[141:160], genes[281:300]),
+        gs_name = rep(c("set_a", "set_b", "set_c"), each = 20)
+    )
+    list(gene_patterns_within_state_graph = gene_patterns_within_state_graph, gene_df = gene_df)
+}
+
+testthat::test_that("calc_gsea_enrichment_on_state_specific_genes is deterministic across repeated calls", {
+    fixture <- test_helper_make_state_gsea_fixture()
+
+    res1 <- platt:::calc_gsea_enrichment_on_state_specific_genes(
+        fixture$gene_patterns_within_state_graph, fixture$gene_df, sig_thresh = 1.0
+    )
+    res2 <- platt:::calc_gsea_enrichment_on_state_specific_genes(
+        fixture$gene_patterns_within_state_graph, fixture$gene_df, sig_thresh = 1.0
+    )
+
+    testthat::expect_true(nrow(res1) > 0)
+    testthat::expect_identical(res1$NES, res2$NES)
+    testthat::expect_identical(res1$padj, res2$padj)
+    testthat::expect_identical(res1$log2err, res2$log2err)
+})
+
+testthat::test_that("calc_gsea_enrichment_on_state_specific_genes surfaces log2err", {
+    fixture <- test_helper_make_state_gsea_fixture()
+
+    res <- platt:::calc_gsea_enrichment_on_state_specific_genes(
+        fixture$gene_patterns_within_state_graph, fixture$gene_df, sig_thresh = 1.0
+    )
+
+    testthat::expect_true("log2err" %in% names(res))
+    testthat::expect_true(all(is.finite(res$log2err)))
+})
+
+testthat::test_that("calc_gsea_enrichment_on_state_specific_genes respects an explicit seed_key", {
+    fixture <- test_helper_make_state_gsea_fixture()
+
+    res1 <- platt:::calc_gsea_enrichment_on_state_specific_genes(
+        fixture$gene_patterns_within_state_graph, fixture$gene_df,
+        sig_thresh = 1.0, seed_key = "stateA::patternX"
+    )
+    res2 <- platt:::calc_gsea_enrichment_on_state_specific_genes(
+        fixture$gene_patterns_within_state_graph, fixture$gene_df,
+        sig_thresh = 1.0, seed_key = "stateA::patternX"
+    )
+
+    testthat::expect_identical(res1$NES, res2$NES)
+    testthat::expect_identical(res1$padj, res2$padj)
+})

--- a/tests/testthat/test-phenotype-assignment-utils.R
+++ b/tests/testthat/test-phenotype-assignment-utils.R
@@ -1,0 +1,97 @@
+test_helper_make_rank_vec_and_sets <- function(seed = 1) {
+    set.seed(seed)
+    genes <- paste0("gene", seq_len(300))
+    rank_vec <- setNames(rnorm(length(genes)), genes)
+    rank_vec <- sort(rank_vec, decreasing = TRUE)
+    gene_sets <- list(
+        set_a = genes[1:20],
+        set_b = genes[141:160],
+        set_c = genes[281:300]
+    )
+    list(rank_vec = rank_vec, gene_sets = gene_sets)
+}
+
+testthat::test_that("run_fgsea_modules is deterministic across repeated calls with identical inputs", {
+    fixture <- test_helper_make_rank_vec_and_sets()
+
+    res1 <- platt:::run_fgsea_modules(
+        fixture$rank_vec, fixture$gene_sets,
+        minSize = 10, maxSize = 500, nperm = 200,
+        seed_key = "perturbA::cellB::fitness"
+    )
+    res2 <- platt:::run_fgsea_modules(
+        fixture$rank_vec, fixture$gene_sets,
+        minSize = 10, maxSize = 500, nperm = 200,
+        seed_key = "perturbA::cellB::fitness"
+    )
+
+    testthat::expect_true(nrow(res1) > 0)
+    testthat::expect_identical(res1$path, res2$path)
+    testthat::expect_identical(res1$NES, res2$NES)
+    testthat::expect_identical(res1$padj, res2$padj)
+    testthat::expect_identical(res1$log2err, res2$log2err)
+})
+
+testthat::test_that("run_fgsea_modules is deterministic with no seed_key supplied (falls back to input-derived seed)", {
+    fixture <- test_helper_make_rank_vec_and_sets()
+
+    res1 <- platt:::run_fgsea_modules(fixture$rank_vec, fixture$gene_sets, minSize = 10, maxSize = 500, nperm = 200)
+    res2 <- platt:::run_fgsea_modules(fixture$rank_vec, fixture$gene_sets, minSize = 10, maxSize = 500, nperm = 200)
+
+    testthat::expect_identical(res1$NES, res2$NES)
+    testthat::expect_identical(res1$padj, res2$padj)
+    testthat::expect_identical(res1$log2err, res2$log2err)
+})
+
+testthat::test_that("run_fgsea_modules surfaces log2err from fgseaMultilevel", {
+    fixture <- test_helper_make_rank_vec_and_sets()
+
+    res <- platt:::run_fgsea_modules(fixture$rank_vec, fixture$gene_sets, minSize = 10, maxSize = 500, nperm = 200)
+
+    testthat::expect_true("log2err" %in% names(res))
+    testthat::expect_true(all(is.finite(res$log2err)))
+})
+
+testthat::test_that("run_fgsea_modules never forwards nperm to fgsea::fgsea (stays on the fgseaMultilevel path)", {
+    fixture <- test_helper_make_rank_vec_and_sets()
+
+    # fgsea::fgsea() only emits the fgseaSimple deprecation warning when it
+    # sees an `nperm` argument in `...`; that warning is the direct symptom
+    # of the bug this fix addresses (previously silenced by suppressWarnings()
+    # around the whole call). If run_fgsea_modules() ever regresses to passing
+    # nperm straight through, this will start failing.
+    testthat::expect_no_warning(
+        withCallingHandlers(
+            fgsea::fgsea(
+                pathways = fixture$gene_sets, stats = fixture$rank_vec,
+                minSize = 10, maxSize = 500, nPermSimple = 200
+            ),
+            warning = function(w) stop(w)
+        )
+    )
+
+    direct <- withr::with_seed(
+        platt:::.fgsea_seed_from_key("perturbA::cellB::fitness"),
+        suppressWarnings(fgsea::fgsea(
+            pathways = fixture$gene_sets, stats = fixture$rank_vec,
+            minSize = 10, maxSize = 500, nPermSimple = 200
+        ))
+    )
+    via_wrapper <- platt:::run_fgsea_modules(
+        fixture$rank_vec, fixture$gene_sets,
+        minSize = 10, maxSize = 500, nperm = 200,
+        seed_key = "perturbA::cellB::fitness"
+    )
+
+    testthat::expect_identical(sort(via_wrapper$NES), sort(direct$NES))
+    testthat::expect_identical(sort(via_wrapper$padj), sort(direct$padj))
+})
+
+testthat::test_that(".fgsea_seed_from_key gives different keys different seeds (order/identity independence)", {
+    s1 <- platt:::.fgsea_seed_from_key("perturbA::cellB::fitness")
+    s2 <- platt:::.fgsea_seed_from_key("perturbA::cellC::fitness")
+    s3 <- platt:::.fgsea_seed_from_key("perturbA::cellB::fitness")
+
+    testthat::expect_identical(s1, s3)
+    testthat::expect_false(identical(s1, s2))
+})


### PR DESCRIPTION
run_fgsea_modules() and calc_gsea_enrichment_on_state_specific_genes() were passing nperm to fgsea::fgsea(), forcing the deprecated fgseaSimple path (padj resolution floored at ~1/(nperm+1)) and silently swallowing its deprecation warning via suppressWarnings(). Neither function nor any caller ever seeded the RNG, so identical inputs produced different NES/padj on every run and could flip borderline phenotype labels.

- Stop forwarding nperm to fgsea::fgsea(); pass it as nPermSimple instead so the dispatcher always resolves to fgseaMultilevel.
- Surface log2err (fgseaMultilevel's per-pathway precision estimate) through to fitness_fgsea.tsv/identity_fgsea.tsv.
- Seed each fgsea() call deterministically via a hash of the call's own identity (perturb_name::cell_group::purpose, or the gene ranking/gene sets themselves when no key is given), wrapped in withr::with_seed() so results are reproducible regardless of loop order, worker count, or serial vs. parallel execution.

Confirmed against real LMX1B v2.2.1 output: the old run had 193 unrelated identity gene sets tied at an identical padj for "mature slow muscle (cyp4t8+)" (fgseaSimple floor collision); the fixed path resolves to 703 distinct padj values for the same input and is byte-identical across repeated calls.